### PR TITLE
Warn when journal folder is missing or is missing files

### DIFF
--- a/auto_neutron/windows/gui/missing_journal_window.py
+++ b/auto_neutron/windows/gui/missing_journal_window.py
@@ -1,0 +1,36 @@
+# This file is part of Auto_Neutron.
+# Copyright (C) 2021  Numerlor
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+# noinspection PyUnresolvedReferences
+from __feature__ import snake_case, true_property  # noqa: F401
+
+
+class MissingJournalWindowGUI(QtWidgets.QDialog):
+    """Display window that forces the user to quit when the journal folder is missing."""
+
+    def __init__(self, parent: QtWidgets.QWidget):
+        super().__init__(parent)
+        self.set_attribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
+        self.set_modal(True)
+
+        self.info_label = QtWidgets.QLabel(
+            "Journal folder not found or missing files.", self
+        )
+        font = QtGui.QFont()
+        font.set_point_size(18)
+        self.info_label.font = font
+
+        self.quit_button = QtWidgets.QPushButton("Quit", self)
+
+        self.main_layout = QtWidgets.QVBoxLayout(self)
+        self.main_layout.add_widget(
+            self.info_label, alignment=QtCore.Qt.AlignmentFlag.AlignCenter
+        )
+        self.main_layout.add_widget(
+            self.quit_button, alignment=QtCore.Qt.AlignmentFlag.AlignCenter
+        )
+
+        self.set_window_flag(QtCore.Qt.WindowCloseButtonHint, False)
+        self.show()

--- a/auto_neutron/windows/missing_journal_window.py
+++ b/auto_neutron/windows/missing_journal_window.py
@@ -1,0 +1,17 @@
+# This file is part of Auto_Neutron.
+# Copyright (C) 2021  Numerlor
+
+from PySide6 import QtWidgets
+
+# noinspection PyUnresolvedReferences
+from __feature__ import snake_case, true_property  # noqa: F401
+from auto_neutron.windows.gui.missing_journal_window import MissingJournalWindowGUI
+
+
+class MissingJournalWindow(MissingJournalWindowGUI):
+    """Wrap the GUI to provide the quit functionality."""
+
+    def __init__(self, parent: QtWidgets.QWidget):
+        super().__init__(parent)
+
+        self.quit_button.pressed.connect(QtWidgets.QApplication.instance().quit)

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -340,11 +340,12 @@ class NewRouteWindow(NewRouteWindowGUI):
 
     def _change_journal(self, index: int) -> None:
         """Change the current journal and update the UI with its data, or display an error if shut down."""
-        journal_path = sorted(
+        journals = sorted(
             JOURNAL_PATH.glob("Journal.*.log"),
             key=lambda path: path.stat().st_ctime,
             reverse=True,
-        )[index]
+        )
+        journal_path = journals[min(index, len(journals) - 1)]
         log.info(f"Changing selected journal to {journal_path}.")
         journal = Journal(journal_path)
         loadout, location, cargo_mass, shut_down = journal.get_static_state()

--- a/auto_neutron/windows/shut_down_window.py
+++ b/auto_neutron/windows/shut_down_window.py
@@ -36,11 +36,12 @@ class ShutDownWindow(ShutDownWindowGUI):
 
     def _change_journal(self, index: int) -> None:
         """Change the selected journal, enable/disable the button depending on its shut down state."""
-        journal_path = sorted(
+        journals = sorted(
             JOURNAL_PATH.glob("Journal.*.log"),
             key=lambda path: path.stat().st_ctime,
             reverse=True,
-        )[index]
+        )
+        journal_path = journals[min(index, len(journals) - 1)]
         journal = Journal(journal_path)
         _, _, _, shut_down = journal.get_static_state()
         self.new_journal_button.enabled = not shut_down


### PR DESCRIPTION
The user will now be warned instead of immediately triggering the error.
when less than three journals are found in the folder, the selected journal will be the latest available closest to the selected index