### PR TITLE
2.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ venv.bak/
 .idea/
 
 logs/
+
+*.mo

--- a/auto_neutron/__init__.py
+++ b/auto_neutron/__init__.py
@@ -1,6 +1,16 @@
+import enum
+
 from PySide6 import QtNetwork
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
 
 network_mgr: QtNetwork.QNetworkAccessManager = None
+
+
+class Theme(enum.IntEnum):
+    """The theme to be used by the app."""
+
+    LIGHT_THEME = 0
+    OS_THEME = 1
+    DARK_THEME = 2

--- a/auto_neutron/constants.py
+++ b/auto_neutron/constants.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import os
 import typing
 from pathlib import Path

--- a/auto_neutron/constants.py
+++ b/auto_neutron/constants.py
@@ -13,7 +13,7 @@ from PySide6 import QtCore
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
 
-VERSION = "2.0.2"
+VERSION = "2.0.3"
 APP = "Auto_Neutron"
 ORG = "Numerlor"
 APPID = f"{ORG}|{APP}|{VERSION}"

--- a/auto_neutron/fuel_warn.py
+++ b/auto_neutron/fuel_warn.py
@@ -34,11 +34,7 @@ class FuelWarn:
 
     def warn(self, status_dict: dict) -> None:
         """Execute alert when in supercruise, on FSD cool down and fuel is below threshold."""
-        if (
-            not status_dict
-            or "Fuel" not in status_dict
-            or self._game_state.ship.fsd is None
-        ):
+        if not status_dict or "Fuel" not in status_dict:
             # Sometimes we get empty JSON,
             # or when the game is shut down it only contains data up to flags.
             return

--- a/auto_neutron/fuel_warn.py
+++ b/auto_neutron/fuel_warn.py
@@ -20,17 +20,22 @@ log = logging.getLogger(__name__)
 IN_SUPERCRUISE_FLAG = 1 << 4
 FSD_COOLDOWN_FLAG = 1 << 18
 
-player = QtMultimedia.QMediaPlayer()
-player.audio_output = audio_output = QtMultimedia.QAudioOutput()
 
-
-class FuelWarn:
+class FuelWarn(QtCore.QObject):
     """Warn visually through the task bar and through audio when fuel is below set threshold."""
 
-    def __init__(self, game_state: GameState, alert_widget: QtWidgets.QWidget):
+    def __init__(
+        self,
+        parent: QtCore.QObject,
+        game_state: GameState,
+        alert_widget: QtWidgets.QWidget,
+    ):
+        super().__init__(parent)
         self._warned = False
         self._alert_widget = alert_widget
         self._game_state = game_state
+        self.player = QtMultimedia.QMediaPlayer(self)
+        self.player.audio_output = self.audio_output = QtMultimedia.QAudioOutput(self)
 
     def warn(self, status_dict: dict) -> None:
         """Execute alert when in supercruise, on FSD cool down and fuel is below threshold."""
@@ -72,10 +77,10 @@ class FuelWarn:
         if settings.Alerts.audio:
             if settings.Paths.alert_sound:
                 new_url = QtCore.QUrl.from_local_file(str(settings.Paths.alert_sound))
-                if new_url != player.source:
-                    player.source = new_url
+                if new_url != self.player.source:
+                    self.player.source = new_url
                 log.info(f"Playing file {settings.Paths.alert_sound} for alert.")
-                player.play()
+                self.player.play()
 
             else:
                 QtWidgets.QApplication.instance().beep()

--- a/auto_neutron/game_state.py
+++ b/auto_neutron/game_state.py
@@ -13,6 +13,7 @@ from PySide6 import QtCore
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron.ship import Ship
+from auto_neutron.utils.forbid_uninitialized import ForbidUninitialized
 from auto_neutron.workers import GameWorker
 
 if t.TYPE_CHECKING:
@@ -41,10 +42,10 @@ class GameState:
     """
 
     ship: Ship = Ship()
-    shut_down: t.Optional[bool] = None
-    location: t.Optional[Location] = None
-    last_target: t.Optional[Location] = None
-    current_cargo: t.Optional[int] = None
+    shut_down: bool = ForbidUninitialized()  # type: ignore
+    location: Location = ForbidUninitialized()  # type: ignore
+    last_target: Location = ForbidUninitialized()  # type: ignore
+    current_cargo: int = ForbidUninitialized()  # type: ignore
 
     def connect_journal(self, journal: Journal) -> None:
         """Connect the signals from `journal` to set the appropriate attributes when emitted."""

--- a/auto_neutron/game_state.py
+++ b/auto_neutron/game_state.py
@@ -62,8 +62,8 @@ class PlotterState(QtCore.QObject):
     new_system_signal = QtCore.Signal(str, int)
     shut_down_signal = QtCore.Signal()
 
-    def __init__(self, game_state: GameState):
-        super().__init__()
+    def __init__(self, parent: QtCore.QObject, game_state: GameState):
+        super().__init__(parent)
         self._game_state = game_state
 
         self._route_index = 0
@@ -80,7 +80,7 @@ class PlotterState(QtCore.QObject):
         """
         assert self.journal is not None, "Journal must be set first."
         if self.tail_worker is None:
-            self.tail_worker = GameWorker(route, self.journal)
+            self.tail_worker = GameWorker(self, route, self.journal)
             if self.plotter is not None:
                 self.tail_worker.new_system_index_sig.connect(
                     partial(setattr, self, "route_index")
@@ -163,7 +163,7 @@ class PlotterState(QtCore.QObject):
 
             if self._plotter is not None:
                 self.tail_worker.stop()
-                self.tail_worker = GameWorker(self.route, self.journal)
+                self.tail_worker = GameWorker(self, self.route, self.journal)
                 self.tail_worker.start()
                 self.tail_worker.new_system_index_sig.connect(
                     partial(setattr, self, "route_index")

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -89,7 +89,6 @@ class Hub(QtCore.QObject):
         self.fuel_warner = FuelWarn(self.game_state, self.window)
         self.warn_worker = StatusWorker()
         self.warn_worker.status_signal.connect(self.fuel_warner.warn)
-        self.warn_worker.start()
 
         self.new_route_window()
 
@@ -145,6 +144,7 @@ class Hub(QtCore.QObject):
         with self.edit_route_update_connection.temporarily_disconnect():
             self.window.initialize_table(route)
         self.plotter_state.route_index = route_index
+        self.warn_worker.start()
 
     def apply_settings(self) -> None:
         """Update the appearance and plotter with new settings."""

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -44,7 +44,9 @@ class Hub(QtCore.QObject):
         self.window = MainWindow()
         self.error_window = ErrorWindow(self.window)
         self.error_window.save_button.pressed.connect(partial(self.save_route, True))
+
         exception_handler.triggered.connect(self.error_window.show)
+        exception_handler.set_parent(self)
         self.window.show()
 
         self.window.about_action.triggered.connect(partial(LicenseWindow, self.window))

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -59,7 +59,7 @@ class Hub(QtCore.QObject):
 
         self.window.show()
 
-        self.window.about_action.triggered.connect(partial(LicenseWindow, self.window))
+        self.window.about_action.triggered.connect(self.display_license_window)
         self.window.new_route_action.triggered.connect(self.new_route_window)
         self.window.settings_action.triggered.connect(self.display_settings)
         self.window.save_action.triggered.connect(self.save_route)
@@ -83,7 +83,7 @@ class Hub(QtCore.QObject):
             or not (JOURNAL_PATH / "Status.json").exists()
         ):
             # If the journal folder is missing, force the user to quit
-            MissingJournalWindow(self.window)
+            MissingJournalWindow(self.window).show()
             return
 
         self.fuel_warner = FuelWarn(self.game_state, self.window)
@@ -99,6 +99,7 @@ class Hub(QtCore.QObject):
         logging.info("Displaying new route window.")
         route_window = NewRouteWindow(self.window)
         route_window.route_created_signal.connect(self.new_route)
+        route_window.show()
 
     def update_route_from_edit(self, table_item: QtWidgets.QTableWidgetItem) -> None:
         """Edit the plotter's route with the new data in `table_item`."""
@@ -174,6 +175,7 @@ class Hub(QtCore.QObject):
         log.info("Displaying settings window.")
         window = SettingsWindow(self.window)
         window.settings_applied.connect(self.apply_settings)
+        window.show()
 
     def display_shut_down_window(self) -> None:
         """Display the shut down window and connect it to create a new route and save the current one."""
@@ -181,6 +183,13 @@ class Hub(QtCore.QObject):
         window = ShutDownWindow(self.window)
         window.new_journal_signal.connect(self.new_route)
         window.save_route_button.pressed.connect(partial(self.save_route, force=True))
+        window.show()
+
+    def display_license_window(self) -> None:
+        """Display the license window."""
+        log.info("Displaying license window.")
+        window = LicenseWindow(self.window)
+        window.show()
 
     def set_theme_from_os(self, dark: bool) -> None:
         """Set the current theme to the OS' theme, if the theme setting is set to follow the OS."""

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -176,7 +176,6 @@ class Hub(QtCore.QObject):
         new_locale = babel.Locale.parse(settings.General.locale)
         if new_locale != auto_neutron.locale.get_active_locale():
             auto_neutron.locale.set_active_locale(new_locale)
-            auto_neutron.locale.install_translation(settings.General.locale)
             app = QtWidgets.QApplication.instance()
             app.post_event(app, QtCore.QEvent(QtCore.QEvent.LanguageChange))
 

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -148,6 +148,7 @@ class Hub(QtCore.QObject):
         with self.edit_route_update_connection.temporarily_disconnect():
             self.window.initialize_table(route)
         self.plotter_state.route_index = route_index
+        self.plotter_state.tail_worker.emit_next_system(self.game_state.location)
         self.warn_worker.start()
 
     def apply_settings(self) -> None:

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -66,7 +66,7 @@ class Hub(QtCore.QObject):
         self.window.table.doubleClicked.connect(self.get_index_row)
         self.game_state = GameState()
 
-        self.plotter_state = PlotterState(self.game_state)
+        self.plotter_state = PlotterState(self, self.game_state)
         self.plotter_state.new_system_signal.connect(self.new_system_callback)
         self.plotter_state.shut_down_signal.connect(self.display_shut_down_window)
 
@@ -86,8 +86,8 @@ class Hub(QtCore.QObject):
             MissingJournalWindow(self.window).show()
             return
 
-        self.fuel_warner = FuelWarn(self.game_state, self.window)
-        self.warn_worker = StatusWorker()
+        self.fuel_warner = FuelWarn(self, self.game_state, self.window)
+        self.warn_worker = StatusWorker(self)
         self.warn_worker.status_signal.connect(self.fuel_warner.warn)
 
         self.new_route_window()

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -172,6 +172,8 @@ class Hub(QtCore.QObject):
                 self.plotter_state.plotter, AhkPlotter
             ):
                 self.plotter_state.plotter = AhkPlotter(start_system=current_sys.system)
+            else:
+                self.plotter_state.plotter.refresh_settings()
 
         new_locale = babel.Locale.parse(settings.General.locale)
         if new_locale != auto_neutron.locale.get_active_locale():

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -9,7 +9,10 @@ import logging
 import typing as t
 from functools import partial
 
+import babel
 from PySide6 import QtCore, QtGui, QtWidgets
+
+import auto_neutron.locale
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
@@ -169,6 +172,13 @@ class Hub(QtCore.QObject):
                 self.plotter_state.plotter, AhkPlotter
             ):
                 self.plotter_state.plotter = AhkPlotter(start_system=current_sys.system)
+
+        new_locale = babel.Locale.parse(settings.General.locale)
+        if new_locale != auto_neutron.locale.get_active_locale():
+            auto_neutron.locale.set_active_locale(new_locale)
+            auto_neutron.locale.install_translation(settings.General.locale)
+            app = QtWidgets.QApplication.instance()
+            app.post_event(app, QtCore.QEvent(QtCore.QEvent.LanguageChange))
 
     def display_settings(self) -> None:
         """Display the settings window and connect the applied signal to refresh appearance."""

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -3,11 +3,9 @@
 
 from __future__ import annotations
 
-import collections.abc
 import json
 import logging
 import typing as t
-from pathlib import Path
 
 from PySide6 import QtCore
 
@@ -15,6 +13,10 @@ from PySide6 import QtCore
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron.game_state import Location
 from auto_neutron.utils.utils import get_sector_midpoint
+
+if t.TYPE_CHECKING:
+    import collections.abc
+    from pathlib import Path
 
 log = logging.getLogger(__name__)
 

--- a/auto_neutron/locale.py
+++ b/auto_neutron/locale.py
@@ -1,0 +1,39 @@
+import functools
+import gettext
+
+import babel
+
+from auto_neutron.utils.file import base_path
+
+_active_locale = None
+
+LOCALE_DIR = base_path() / "locale"
+
+
+def get_active_locale() -> babel.Locale:
+    """Get the current active locale."""
+    assert _active_locale is not None, "Locale uninitialized."
+    return _active_locale
+
+
+def set_active_locale(locale: babel.Locale) -> None:
+    """Set the current active locale."""
+    global _active_locale
+    _active_locale = locale
+
+
+def install_translation(language: str) -> None:
+    """Install the translations for `language`."""
+    gettext.translation(
+        "auto_neutron", localedir=LOCALE_DIR, languages=[language]
+    ).install()
+
+
+@functools.cache
+def get_available_languages() -> list[str]:
+    """Get the languages translations are available for."""
+    return [
+        path.name
+        for path in LOCALE_DIR.glob("*")
+        if path.is_dir() and (path / "LC_MESSAGES" / "auto_neutron.mo").exists()
+    ]

--- a/auto_neutron/locale.py
+++ b/auto_neutron/locale.py
@@ -23,15 +23,18 @@ def set_active_locale(locale: babel.Locale) -> None:
     gettext.translation(
         "auto_neutron",
         localedir=LOCALE_DIR,
-        languages=[
-            "".join(
-                filter(
-                    None,
-                    (locale.language, locale.territory, locale.script, locale.variant),
-                )
-            )
-        ],
+        languages=[code_from_locale(locale)],
     ).install()
+
+
+def code_from_locale(locale: babel.Locale) -> str:
+    """Get the language code of `locale`."""
+    return "".join(
+        filter(
+            None,
+            (locale.language, locale.territory, locale.script, locale.variant),
+        )
+    )
 
 
 @functools.cache

--- a/auto_neutron/locale.py
+++ b/auto_neutron/locale.py
@@ -35,10 +35,10 @@ def set_active_locale(locale: babel.Locale) -> None:
 
 
 @functools.cache
-def get_available_languages() -> list[str]:
-    """Get the languages translations are available for."""
+def get_available_locales() -> list[babel.Locale]:
+    """Get the locales translations are available for."""
     return [
-        path.name
+        babel.Locale.parse(path.name)
         for path in LOCALE_DIR.glob("*")
         if path.is_dir() and (path / "LC_MESSAGES" / "auto_neutron.mo").exists()
     ]

--- a/auto_neutron/locale.py
+++ b/auto_neutron/locale.py
@@ -20,12 +20,17 @@ def set_active_locale(locale: babel.Locale) -> None:
     """Set the current active locale."""
     global _active_locale
     _active_locale = locale
-
-
-def install_translation(language: str) -> None:
-    """Install the translations for `language`."""
     gettext.translation(
-        "auto_neutron", localedir=LOCALE_DIR, languages=[language]
+        "auto_neutron",
+        localedir=LOCALE_DIR,
+        languages=[
+            "".join(
+                filter(
+                    None,
+                    (locale.language, locale.territory, locale.script, locale.variant),
+                )
+            )
+        ],
     ).install()
 
 

--- a/auto_neutron/locale.py
+++ b/auto_neutron/locale.py
@@ -29,7 +29,7 @@ def set_active_locale(locale: babel.Locale) -> None:
 
 def code_from_locale(locale: babel.Locale) -> str:
     """Get the language code of `locale`."""
-    return "".join(
+    return "_".join(
         filter(
             None,
             (locale.language, locale.territory, locale.script, locale.variant),

--- a/auto_neutron/route_plots.py
+++ b/auto_neutron/route_plots.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import abc
 import atexit
-import collections.abc
 import contextlib
 import dataclasses
 import logging
@@ -26,6 +25,9 @@ from auto_neutron.utils.network import (
     json_from_network_req,
     make_network_request,
 )
+
+if t.TYPE_CHECKING:
+    import collections.abc
 
 log = logging.getLogger(__name__)
 

--- a/auto_neutron/route_plots.py
+++ b/auto_neutron/route_plots.py
@@ -126,11 +126,14 @@ class Plotter(abc.ABC):
             self.update_system(start_system)
 
     @abc.abstractmethod
-    def update_system(self, system: str, system_index: t.Optional[int] = None) -> t.Any:
+    def update_system(self, system: str, system_index: t.Optional[int] = None) -> None:
         """Update the plotter with the given system."""
         ...
 
-    def stop(self) -> t.Any:
+    def refresh_settings(self) -> None:
+        """Refresh the settings."""
+
+    def stop(self) -> None:
         """Stop the plotter."""
         ...
 
@@ -187,12 +190,6 @@ class AhkPlotter(Plotter):
 
     def update_system(self, system: str, system_index: t.Optional[int] = None) -> None:
         """Update the ahk script with `system`."""
-        if (
-            settings.Paths.ahk != self._used_ahk_path
-            or settings.General.script != self._used_script
-            or settings.General.bind != self._used_hotkey
-        ):
-            self.stop()
         if self.process is None or self.process.poll() is not None:
             self._start_ahk()
         self._last_system = system
@@ -202,6 +199,16 @@ class AhkPlotter(Plotter):
         self.ahk_infile.flush()
         self.ahk_infile.seek(0)
         log.debug(f"Wrote {system!r} to AHK.")
+
+    def refresh_settings(self) -> None:
+        """Restart AHK on setting change."""
+        if (
+            settings.Paths.ahk != self._used_ahk_path
+            or settings.General.script != self._used_script
+            or settings.General.bind != self._used_hotkey
+        ):
+            self._start_ahk()
+            self.update_system(self._last_system)
 
     def stop(self) -> None:
         """Terminate the active process, if any."""

--- a/auto_neutron/settings/__init__.py
+++ b/auto_neutron/settings/__init__.py
@@ -3,7 +3,7 @@
 
 from .default_settings_obj import get_settings, set_settings  # isort:skip
 from .categories import Alerts, General, Paths, Window
-from .category_meta import SettingsCategory, SettingsParams
+from .category_meta import SettingsCategory, SettingsParams, delay_sync
 
 __all__ = [
     "General",
@@ -12,6 +12,7 @@ __all__ = [
     "Alerts",
     "SettingsParams",
     "SettingsCategory",
+    "delay_sync",
     "set_settings",
     "get_settings",
 ]

--- a/auto_neutron/settings/categories.py
+++ b/auto_neutron/settings/categories.py
@@ -44,6 +44,7 @@ class General(metaclass=SettingsCategory):  # noqa D101
     ]
     copy_mode: t.Annotated[bool, SettingsParams(True)]
     last_route_index: t.Annotated[int, SettingsParams(0)]
+    locale: t.Annotated[str, SettingsParams("en")]
 
 
 def _path_serializer(path: t.Union[None, Path, str]) -> str:

--- a/auto_neutron/settings/categories.py
+++ b/auto_neutron/settings/categories.py
@@ -10,6 +10,7 @@ from PySide6.QtGui import QFont
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa F401
+from auto_neutron import Theme
 
 from .category_meta import SettingsCategory, SettingsParams
 
@@ -85,7 +86,7 @@ class Window(metaclass=SettingsCategory):  # noqa D101
             lambda val: QByteArray(b64decode(val.encode())),
         ),
     ]
-    dark_mode: t.Annotated[bool, SettingsParams(True)]
+    dark_mode: t.Annotated[Theme, SettingsParams(True, None, Theme)]
     autoscroll: t.Annotated[bool, SettingsParams(True)]
     font: t.Annotated[
         QFont,

--- a/auto_neutron/settings/category_meta.py
+++ b/auto_neutron/settings/category_meta.py
@@ -147,7 +147,7 @@ class SettingsCategory(type):
         """Try to find a `SettingsParams` object in a `typing.Annotated` `annotation`."""
         annotation_args = t.get_args(annotation)
         return next(
-            filter(lambda ann: isinstance(ann, SettingsParams), annotation_args), None
+            (ann for ann in annotation_args if isinstance(ann, SettingsParams)), None
         )
 
 

--- a/auto_neutron/ship.py
+++ b/auto_neutron/ship.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import typing as t
 
 from auto_neutron.constants import BOOSTER_CONSTANTS, FSD_CONSTANTS, FrameShiftDrive

--- a/auto_neutron/ship.py
+++ b/auto_neutron/ship.py
@@ -3,9 +3,8 @@
 
 from __future__ import annotations
 
-import typing as t
-
 from auto_neutron.constants import BOOSTER_CONSTANTS, FSD_CONSTANTS, FrameShiftDrive
+from auto_neutron.utils.forbid_uninitialized import ForbidUninitialized
 
 _RATING_TO_CLASS = {"A": 5, "B": 4, "C": 3, "D": 2, "E": 1}
 
@@ -16,13 +15,20 @@ _MASS_MANAGER_MODIFIER = 1.04  # Adds 4% to optimal mass
 class Ship:
     """Hold stats of a ship required for plotting."""
 
+    fsd = ForbidUninitialized()
+    jump_range_boost = ForbidUninitialized()
+    tank_size = ForbidUninitialized()
+    reserve_size = ForbidUninitialized()
+    unladen_mass = ForbidUninitialized()
+    max_cargo = ForbidUninitialized()
+
     def __init__(self):
-        self.fsd: t.Optional[FrameShiftDrive] = None
-        self.jump_range_boost: t.Optional[float] = None
-        self.tank_size: t.Optional[int] = None
-        self.reserve_size: t.Optional[float] = None
-        self.unladen_mass: t.Optional[float] = None
-        self.max_cargo: t.Optional[int] = None
+        self.fsd: FrameShiftDrive = None  # type: ignore
+        self.jump_range_boost: float = None  # type: ignore
+        self.tank_size: int = None  # type: ignore
+        self.reserve_size: float = None  # type: ignore
+        self.unladen_mass: float = None  # type: ignore
+        self.max_cargo: int = None  # type: ignore
 
     def jump_range(self, *, cargo_mass: int) -> float:
         """Calculate the jump range with `cargo_mass` t of cargo."""

--- a/auto_neutron/utils/file.py
+++ b/auto_neutron/utils/file.py
@@ -6,11 +6,10 @@ from __future__ import annotations
 import ctypes
 import msvcrt
 import os
+import sys
 import typing as t
 from ctypes import wintypes
-
-if t.TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
 
 GENERIC_WRITE = 0x40000000
 FILE_SHARE_DELETE = 0x00000004
@@ -81,3 +80,8 @@ def get_file_name(file: t.IO) -> str:
         raise ctypes.WinError()
 
     return buffer.value.removeprefix("\\\\?\\")
+
+
+def base_path() -> Path:
+    """Get the script's base path, using pyinstaller's temp directory when built, the project root otherwise."""
+    return Path(getattr(sys, "_MEIPASS", Path(sys.argv[0]).parent))

--- a/auto_neutron/utils/file.py
+++ b/auto_neutron/utils/file.py
@@ -1,12 +1,16 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import ctypes
 import msvcrt
 import os
 import typing as t
 from ctypes import wintypes
-from pathlib import Path
+
+if t.TYPE_CHECKING:
+    from pathlib import Path
 
 GENERIC_WRITE = 0x40000000
 FILE_SHARE_DELETE = 0x00000004

--- a/auto_neutron/utils/forbid_uninitialized.py
+++ b/auto_neutron/utils/forbid_uninitialized.py
@@ -39,7 +39,7 @@ class ForbidUninitialized:
         if instance is None:
             return self
 
-        value = getattr(instance, self._private_name)
+        value = getattr(instance, self._private_name, self.uninitialized_value)
         if value is self.uninitialized_value:
             raise RuntimeError(
                 f"Access of uninitialized attribute {self._name!r} from {instance}."

--- a/auto_neutron/utils/forbid_uninitialized.py
+++ b/auto_neutron/utils/forbid_uninitialized.py
@@ -1,0 +1,51 @@
+# This file is part of Auto_Neutron.
+# Copyright (C) 2019  Numerlor
+
+from __future__ import annotations
+
+import typing as t
+
+if t.TYPE_CHECKING:
+    from typing_extensions import Self
+
+
+class ForbidUninitialized:
+    """
+    Descriptor that raises on access of initialized attributes.
+
+    The uninitialized value to raise on is taken as an argument, and None by default.
+    """
+
+    def __init__(self, uninitialized_value: object = None):
+        self.uninitialized_value = uninitialized_value
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        """Save the attribute's name and create a private name for use by the descriptor on the instance."""
+        self._name = name
+        self._private_name = f"_{self.__class__.__name__}_" + name
+
+    @t.overload
+    def __get__(self, instance: None, owner: None) -> Self:
+        ...
+
+    @t.overload
+    def __get__(self, instance: object, owner: t.Optional[type] = ...) -> object:
+        ...
+
+    def __get__(
+        self, instance: t.Optional[object], owner: t.Optional[type] = None
+    ) -> t.Union[Self, object]:
+        """If called from a class, return the descriptor, otherwise return the attribute or raise a RuntimeError."""
+        if instance is None:
+            return self
+
+        value = getattr(instance, self._private_name)
+        if value is self.uninitialized_value:
+            raise RuntimeError(
+                f"Access of uninitialized attribute {self._name!r} from {instance}."
+            )
+        return value
+
+    def __set__(self, instance: object, value: object) -> None:
+        """Set the attribute's value."""
+        setattr(instance, self._private_name, value)

--- a/auto_neutron/utils/logging.py
+++ b/auto_neutron/utils/logging.py
@@ -1,7 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
-import collections.abc
+from __future__ import annotations
+
 import logging
 import os
 import typing as t
@@ -14,6 +15,9 @@ from PySide6 import QtCore
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa F401
 from auto_neutron.utils.file import create_delete_share_file
+
+if t.TYPE_CHECKING:
+    import collections.abc
 
 log = logging.getLogger(__name__)
 

--- a/auto_neutron/utils/network.py
+++ b/auto_neutron/utils/network.py
@@ -1,7 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
-import collections.abc
+from __future__ import annotations
+
 import json
 import logging
 import typing as t
@@ -14,6 +15,9 @@ import auto_neutron
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa F401
+
+if t.TYPE_CHECKING:
+    import collections.abc
 
 log = logging.getLogger(__name__)
 

--- a/auto_neutron/utils/recursive_default_dict.py
+++ b/auto_neutron/utils/recursive_default_dict.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
-import collections.abc
 import typing as t
 from contextlib import contextmanager
+
+if t.TYPE_CHECKING:
+    import collections.abc
 
 _KT = t.TypeVar("_KT")
 _VT = t.TypeVar("_VT")

--- a/auto_neutron/utils/recursive_default_dict.py
+++ b/auto_neutron/utils/recursive_default_dict.py
@@ -10,9 +10,10 @@ from contextlib import contextmanager
 if t.TYPE_CHECKING:
     import collections.abc
 
+    import typing_extensions as te
+
 _KT = t.TypeVar("_KT")
 _VT = t.TypeVar("_VT")
-_S = t.TypeVar("_S", bound="RecursiveDefaultDict")
 _DEFAULT_SENTINEL = object()
 
 
@@ -36,7 +37,7 @@ class RecursiveDefaultDict(dict[_KT, _VT], t.Generic[_KT, _VT]):
         self._create_missing = create_missing
 
     def update_from_dict_recursive(
-        self: _S, dict_: dict[_KT, _VT], *, ignore_conflicts: bool = True
+        self, dict_: dict[_KT, _VT], *, ignore_conflicts: bool = True
     ) -> None:
         """Add the contents from `dict_` and replaces all dictionaries with this type."""
         with self.disable_defaults_for_missing():
@@ -89,7 +90,7 @@ class RecursiveDefaultDict(dict[_KT, _VT], t.Generic[_KT, _VT]):
         """Return whether this dict should create new defaults on missing keys."""
         self._create_missing = create_missing
 
-    def __missing__(self: _S, key: _KT) -> _S:
+    def __missing__(self, key: _KT) -> te.Self:
         if self.create_missing:
             created_dict = self.__class__(create_missing=None, parent=self)
             self[key] = created_dict

--- a/auto_neutron/utils/recursive_default_dict.py
+++ b/auto_neutron/utils/recursive_default_dict.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import typing as t
+import warnings
 from contextlib import contextmanager
 
 if t.TYPE_CHECKING:
@@ -47,7 +48,14 @@ class RecursiveDefaultDict(dict[_KT, _VT], t.Generic[_KT, _VT]):
 
                     new_dict = self.__class__(create_missing=None, parent=self)
                     if key in self:
-                        new_dict.update_from_dict_recursive(self[key])
+                        self_value = self[key]
+                        if not isinstance(self_value, dict):
+                            warnings.warn(
+                                f"Overwriting non dict type: {self_value!r} with key: {key!r}.",
+                                RuntimeWarning,
+                            )
+                        else:
+                            new_dict.update_from_dict_recursive(self_value)
                     new_dict.update_from_dict_recursive(value)
                     value = new_dict
 

--- a/auto_neutron/utils/recursive_default_dict.py
+++ b/auto_neutron/utils/recursive_default_dict.py
@@ -17,7 +17,9 @@ _VT = t.TypeVar("_VT")
 _DEFAULT_SENTINEL = object()
 
 
-class RecursiveDefaultDict(dict[_KT, _VT], t.Generic[_KT, _VT]):
+class RecursiveDefaultDict(
+    dict[_KT, t.Union[_VT, "RecursiveDefaultDict"]], t.Generic[_KT, _VT]
+):
     """
     A recursive default dict.
 

--- a/auto_neutron/utils/recursive_default_dict.py
+++ b/auto_neutron/utils/recursive_default_dict.py
@@ -52,8 +52,8 @@ class RecursiveDefaultDict(
                         self._check_conflict(self, key, value)
 
                     new_dict = self.__class__(create_missing=None, parent=self)
-                    if key in self:
-                        self_value = self[key]
+                    self_value = self.get(key, _DEFAULT_SENTINEL)
+                    if self_value is not _DEFAULT_SENTINEL:
                         if not isinstance(self_value, RecursiveDefaultDict):
                             warnings.warn(
                                 f"Overwriting non RecursiveDefaultDict type: {self_value!r} with key: {key!r}.",

--- a/auto_neutron/utils/signal.py
+++ b/auto_neutron/utils/signal.py
@@ -1,13 +1,18 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
-import collections.abc
+from __future__ import annotations
+
+import typing as t
 from contextlib import contextmanager
 
 from PySide6 import QtCore
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
+
+if t.TYPE_CHECKING:
+    import collections.abc
 
 
 class ReconnectingSignal:

--- a/auto_neutron/utils/utils.py
+++ b/auto_neutron/utils/utils.py
@@ -1,18 +1,22 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
-import collections.abc
+from __future__ import annotations
+
 import itertools
 import logging
 import typing as t
 from pathlib import Path
-from types import TracebackType
 
 from PySide6 import QtCore, QtWidgets
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa F401
 from auto_neutron.utils.logging import patch_log_module
+
+if t.TYPE_CHECKING:
+    import collections.abc
+    from types import TracebackType
 
 log = logging.getLogger(__name__)
 

--- a/auto_neutron/utils/utils.py
+++ b/auto_neutron/utils/utils.py
@@ -58,9 +58,9 @@ class ExceptionHandler(QtCore.QObject):
         self.triggered.emit()
 
 
-def create_interrupt_timer() -> QtCore.QTimer:
+def create_interrupt_timer(parent: QtCore.QObject) -> QtCore.QTimer:
     """Interrupt the Qt event loop regularly to let python process signals."""
-    timer = QtCore.QTimer()
+    timer = QtCore.QTimer(parent)
     timer.interval = 50
     timer.timeout.connect(lambda: None)
     timer.start()

--- a/auto_neutron/windows/error_window.py
+++ b/auto_neutron/windows/error_window.py
@@ -18,10 +18,12 @@ root_logger = logging.getLogger()
 
 ISSUES_URL = "https://github.com/Numerlor/Auto_Neutron/issues/new"
 ERROR_TEXT = (
-    "Please make sure to report the bug at <br>"
-    f'<a href="{ISSUES_URL}" style="color: #007bff">{ISSUES_URL}</a>,<br>'
-    "and include the {file_name} file from<br>"
-    ' <a href="{log_path}" style="color: #007bff">{log_path}</a>'
+    _("Please make sure to report the bug at")
+    + "<br>"
+    + f'<a href="{ISSUES_URL}" style="color: #007bff">{ISSUES_URL}</a>,<br>'
+    + _("and include the {file_name} file from")
+    + "<br>"
+    + ' <a href="{log_path}" style="color: #007bff">{log_path}</a>'
 )
 
 
@@ -37,6 +39,7 @@ class ErrorWindow(ErrorWindowGUI):
         self._num_errors = 0
         super().__init__(parent)
         self.quit_button.pressed.connect(QtWidgets.QApplication.instance().quit)
+        self.retranslate()
 
     def _set_text(self) -> None:
         """Set the help text to point the user to the current log file."""
@@ -53,11 +56,9 @@ class ErrorWindow(ErrorWindowGUI):
         self._set_text()
         self._num_errors += 1
         if self._num_errors > 1:
-            self.info_label.text = (
-                "Multiple unexpected errors have occurred (x{})".format(
-                    self._num_errors
-                )
-            )
+            self.info_label.text = _(
+                "Multiple unexpected errors have occurred (x{})"
+            ).format(self._num_errors)
         else:
             super().show()
 
@@ -80,3 +81,10 @@ class ErrorWindow(ErrorWindowGUI):
             return Path(get_file_name(handler.stream)).name
         else:
             return None
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        super().retranslate()
+        self.info_label.text = _(
+            "Multiple unexpected errors have occurred (x{})"
+        ).format(self._num_errors)

--- a/auto_neutron/windows/error_window.py
+++ b/auto_neutron/windows/error_window.py
@@ -17,14 +17,6 @@ from auto_neutron.windows.gui.error_window import ErrorWindowGUI
 root_logger = logging.getLogger()
 
 ISSUES_URL = "https://github.com/Numerlor/Auto_Neutron/issues/new"
-ERROR_TEXT = (
-    _("Please make sure to report the bug at")
-    + "<br>"
-    + f'<a href="{ISSUES_URL}" style="color: #007bff">{ISSUES_URL}</a>,<br>'
-    + _("and include the {file_name} file from")
-    + "<br>"
-    + ' <a href="{log_path}" style="color: #007bff">{log_path}</a>'
-)
 
 
 class ErrorWindow(ErrorWindowGUI):
@@ -39,6 +31,7 @@ class ErrorWindow(ErrorWindowGUI):
         self._num_errors = 0
         super().__init__(parent)
         self.quit_button.pressed.connect(QtWidgets.QApplication.instance().quit)
+        self.error_template = ""
         self.retranslate()
 
     def _set_text(self) -> None:
@@ -47,7 +40,7 @@ class ErrorWindow(ErrorWindowGUI):
             QtCore.QStandardPaths.AppConfigLocation
         )
         file_name = self._get_log_file_name()
-        self.text_browser.html = ERROR_TEXT.format(
+        self.text_browser.html = self.error_template.format(
             log_path=log_path, file_name=file_name
         )
 
@@ -88,3 +81,12 @@ class ErrorWindow(ErrorWindowGUI):
         self.info_label.text = _(
             "Multiple unexpected errors have occurred (x{})"
         ).format(self._num_errors)
+        self.error_template = (
+            _("Please make sure to report the bug at")
+            + "<br>"
+            + f'<a href="{ISSUES_URL}" style="color: #007bff">{ISSUES_URL}</a>,<br>'
+            + _("and include the {file_name} file from")
+            + "<br>"
+            + ' <a href="{log_path}" style="color: #007bff">{log_path}</a>'
+        )
+        self._set_text()

--- a/auto_neutron/windows/error_window.py
+++ b/auto_neutron/windows/error_window.py
@@ -66,9 +66,10 @@ class ErrorWindow(ErrorWindowGUI):
     def _get_log_file_name(self) -> t.Optional[str]:
         """Get the file name of the current active file logger, or None if none are used."""
         handler = next(
-            filter(
-                lambda handler: isinstance(handler, logging.FileHandler),
-                root_logger.handlers,
+            (
+                handler
+                for handler in root_logger.handlers
+                if isinstance(handler, logging.FileHandler)
             ),
             None,
         )

--- a/auto_neutron/windows/error_window.py
+++ b/auto_neutron/windows/error_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import logging
 import typing as t
 from pathlib import Path

--- a/auto_neutron/windows/error_window.py
+++ b/auto_neutron/windows/error_window.py
@@ -75,6 +75,11 @@ class ErrorWindow(ErrorWindowGUI):
         else:
             return None
 
+    def change_event(self, event: QtCore.QEvent) -> None:
+        """Retranslate the GUI when a language change occurs."""
+        if event.type() == QtCore.QEvent.LanguageChange:
+            self.retranslate()
+
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""
         super().retranslate()

--- a/auto_neutron/windows/error_window.py
+++ b/auto_neutron/windows/error_window.py
@@ -54,7 +54,9 @@ class ErrorWindow(ErrorWindowGUI):
         self._num_errors += 1
         if self._num_errors > 1:
             self.info_label.text = (
-                f"Multiple unexpected errors have occurred (x{self._num_errors})"
+                "Multiple unexpected errors have occurred (x{})".format(
+                    self._num_errors
+                )
             )
         else:
             super().show()

--- a/auto_neutron/windows/gui/delegates.py
+++ b/auto_neutron/windows/gui/delegates.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 from typing import Union
 
 from PySide6 import QtCore, QtGui, QtWidgets

--- a/auto_neutron/windows/gui/error_window.py
+++ b/auto_neutron/windows/gui/error_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 from PySide6 import QtGui, QtWidgets
 
 # noinspection PyUnresolvedReferences

--- a/auto_neutron/windows/gui/error_window.py
+++ b/auto_neutron/windows/gui/error_window.py
@@ -16,17 +16,17 @@ class ErrorWindowGUI(QtWidgets.QDialog):
         super().__init__(parent)
         self.main_layout = QtWidgets.QVBoxLayout(self)
 
-        self.info_label = QtWidgets.QLabel()
+        self.info_label = QtWidgets.QLabel(self)
         font = QtGui.QFont()
         font.set_point_size(15)
         self.info_label.font = font
 
-        self.text_browser = QtWidgets.QTextBrowser()
+        self.text_browser = QtWidgets.QTextBrowser(self)
         self.text_browser.open_external_links = True
 
         self.button_layout = QtWidgets.QHBoxLayout()
-        self.quit_button = QtWidgets.QPushButton()
-        self.save_button = QtWidgets.QPushButton()
+        self.quit_button = QtWidgets.QPushButton(self)
+        self.save_button = QtWidgets.QPushButton(self)
         self.quit_button.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )

--- a/auto_neutron/windows/gui/error_window.py
+++ b/auto_neutron/windows/gui/error_window.py
@@ -16,7 +16,7 @@ class ErrorWindowGUI(QtWidgets.QDialog):
         super().__init__(parent)
         self.main_layout = QtWidgets.QVBoxLayout(self)
 
-        self.info_label = QtWidgets.QLabel("An unexpected error has occurred")
+        self.info_label = QtWidgets.QLabel()
         font = QtGui.QFont()
         font.set_point_size(15)
         self.info_label.font = font
@@ -25,8 +25,8 @@ class ErrorWindowGUI(QtWidgets.QDialog):
         self.text_browser.open_external_links = True
 
         self.button_layout = QtWidgets.QHBoxLayout()
-        self.quit_button = QtWidgets.QPushButton("Quit")
-        self.save_button = QtWidgets.QPushButton("Save route")
+        self.quit_button = QtWidgets.QPushButton()
+        self.save_button = QtWidgets.QPushButton()
         self.quit_button.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
@@ -41,3 +41,9 @@ class ErrorWindowGUI(QtWidgets.QDialog):
         self.main_layout.add_widget(self.text_browser)
         self.main_layout.add_layout(self.button_layout)
         self.set_modal(True)
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        self.info_label.text = _("An unexpected error has occurred")
+        self.quit_button.text = _("Quit")
+        self.save_button.text = _("Save route")

--- a/auto_neutron/windows/gui/license_window.py
+++ b/auto_neutron/windows/gui/license_window.py
@@ -44,3 +44,8 @@ class LicenseWindow(QtWidgets.QDialog):
             + '<a href="https://www.gnu.org/licenses/" style="color: #007bff">click here</a> for details.'
         )
         # fmt: on
+
+    def change_event(self, event: QtCore.QEvent) -> None:
+        """Retranslate the GUI when a language change occurs."""
+        if event.type() == QtCore.QEvent.LanguageChange:
+            self.retranslate()

--- a/auto_neutron/windows/gui/license_window.py
+++ b/auto_neutron/windows/gui/license_window.py
@@ -31,7 +31,6 @@ class LicenseWindow(QtWidgets.QDialog):
         self.set_layout(self.main_layout)
 
         self.retranslate()
-        self.show()
 
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""

--- a/auto_neutron/windows/gui/license_window.py
+++ b/auto_neutron/windows/gui/license_window.py
@@ -30,12 +30,18 @@ class LicenseWindow(QtWidgets.QDialog):
         self.main_layout.add_widget(self.text)
         self.set_layout(self.main_layout)
 
-        self.text.insert_html(
-            "PySide6 Copyright (C) 2015 The Qt Company Ltd.<br><br>"
-            "Auto_Neutron Copyright (C) 2019 Numerlor<br>"
-            "Auto_Neutron comes with ABSOLUTELY NO WARRANTY.<br>"
-            "This is free software, and you are welcome to redistribute it under certain conditions; "
-            '<a href="https://www.gnu.org/licenses/" style="color: #007bff">click here</a> for details.'
-        )
-
+        self.retranslate()
         self.show()
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        self.text.clear()
+        # fmt: off
+        self.text.insert_html(
+            _("PySide6 Copyright (C) 2015 The Qt Company Ltd.") + "<br><br>"
+            + _("Auto_Neutron Copyright (C) 2019 Numerlor") + "<br>"
+            + _("Auto_Neutron comes with ABSOLUTELY NO WARRANTY).") + "<br>"
+            + _("This is free software, and you are welcome to redistribute it under certain conditions; ")
+            + '<a href="https://www.gnu.org/licenses/" style="color: #007bff">click here</a> for details.'
+        )
+        # fmt: on

--- a/auto_neutron/windows/gui/license_window.py
+++ b/auto_neutron/windows/gui/license_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import typing as t
 
 from PySide6 import QtCore, QtWidgets

--- a/auto_neutron/windows/gui/main_window.py
+++ b/auto_neutron/windows/gui/main_window.py
@@ -1,7 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
-import collections.abc
+from __future__ import annotations
+
 import typing as t
 
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -13,6 +14,9 @@ from auto_neutron.windows.gui.delegates import (
     DoubleSpinBoxDelegate,
     SpinBoxDelegate,
 )
+
+if t.TYPE_CHECKING:
+    import collections.abc
 
 
 class MainWindowGUI(QtWidgets.QMainWindow):

--- a/auto_neutron/windows/gui/main_window.py
+++ b/auto_neutron/windows/gui/main_window.py
@@ -24,7 +24,7 @@ class MainWindowGUI(QtWidgets.QMainWindow):
 
     def __init__(self):
         super().__init__()
-        self.table = QtWidgets.QTableWidget()
+        self.table = QtWidgets.QTableWidget(self)
         self._double_spinbox_delegate = DoubleSpinBoxDelegate()
         self._spinbox_delegate = SpinBoxDelegate()
         self._checkbox_delegate = CheckBoxDelegate()

--- a/auto_neutron/windows/gui/main_window.py
+++ b/auto_neutron/windows/gui/main_window.py
@@ -32,12 +32,12 @@ class MainWindowGUI(QtWidgets.QMainWindow):
 
         self._setup_table()
 
-        self.change_action = QtGui.QAction("Edit", self)
-        self.save_action = QtGui.QAction("Save route", self)
-        self.copy_action = QtGui.QAction("Copy", self)
-        self.new_route_action = QtGui.QAction("Start a new route", self)
-        self.settings_action = QtGui.QAction("Settings", self)
-        self.about_action = QtGui.QAction("About", self)
+        self.change_action = QtGui.QAction(self)
+        self.save_action = QtGui.QAction(self)
+        self.copy_action = QtGui.QAction(self)
+        self.new_route_action = QtGui.QAction(self)
+        self.settings_action = QtGui.QAction(self)
+        self.about_action = QtGui.QAction(self)
 
         self.context_menu_policy = QtCore.Qt.ContextMenuPolicy.CustomContextMenu
         self.table.context_menu_policy = QtCore.Qt.ContextMenuPolicy.CustomContextMenu
@@ -76,10 +76,6 @@ class MainWindowGUI(QtWidgets.QMainWindow):
         self.table.set_item_delegate_for_column(2, self._double_spinbox_delegate)
         # 3rd column delegate is variable and set by the subclass
         self.table.set_item_delegate_for_column(4, self._checkbox_delegate)
-
-        self.table.horizontal_header_item(0).set_text("System name")
-        self.table.horizontal_header_item(1).set_text("Distance")
-        self.table.horizontal_header_item(2).set_text("Remaining")
 
     def inactivate_before_index(self, index: int) -> None:
         """Make all the items before `index` grey, and after, the default color."""
@@ -124,3 +120,22 @@ class MainWindowGUI(QtWidgets.QMainWindow):
             item.set_data(QtCore.Qt.ItemDataRole.DisplayRole, data_item)
             item.set_text_alignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             self.table.set_item(row_pos, column, item)
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        self._set_header_text()
+        self.change_action.text = _("Edit")
+        self.save_action.text = _("Save route")
+        self.copy_action.text = _("Copy")
+        self.new_route_action.text = _("Start a new route")
+        self.settings_action.text = _("Settings")
+        self.about_action.text = _("About")
+
+    def _set_header_text(self) -> None:
+        """Set header text on existing headers."""
+        if (header := self.table.horizontal_header_item(0)) is not None:
+            header.set_text(_("System name"))
+        if (header := self.table.horizontal_header_item(1)) is not None:
+            header.set_text(_("Distance"))
+        if (header := self.table.horizontal_header_item(3)) is not None:
+            header.set_text(_("Remaining"))

--- a/auto_neutron/windows/gui/missing_journal_window.py
+++ b/auto_neutron/windows/gui/missing_journal_window.py
@@ -33,7 +33,6 @@ class MissingJournalWindowGUI(QtWidgets.QDialog):
         )
 
         self.set_window_flag(QtCore.Qt.WindowCloseButtonHint, False)
-        self.show()
 
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""

--- a/auto_neutron/windows/gui/missing_journal_window.py
+++ b/auto_neutron/windows/gui/missing_journal_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 from PySide6 import QtCore, QtGui, QtWidgets
 
 # noinspection PyUnresolvedReferences

--- a/auto_neutron/windows/gui/missing_journal_window.py
+++ b/auto_neutron/windows/gui/missing_journal_window.py
@@ -17,14 +17,12 @@ class MissingJournalWindowGUI(QtWidgets.QDialog):
         self.set_attribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
         self.set_modal(True)
 
-        self.info_label = QtWidgets.QLabel(
-            "Journal folder not found or missing files.", self
-        )
+        self.info_label = QtWidgets.QLabel(self)
         font = QtGui.QFont()
         font.set_point_size(18)
         self.info_label.font = font
 
-        self.quit_button = QtWidgets.QPushButton("Quit", self)
+        self.quit_button = QtWidgets.QPushButton(self)
 
         self.main_layout = QtWidgets.QVBoxLayout(self)
         self.main_layout.add_widget(
@@ -36,3 +34,8 @@ class MissingJournalWindowGUI(QtWidgets.QDialog):
 
         self.set_window_flag(QtCore.Qt.WindowCloseButtonHint, False)
         self.show()
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        self.info_label.text = _("Journal folder not found or missing files.")
+        self.quit_button.text = _("Quit")

--- a/auto_neutron/windows/gui/nearest_window.py
+++ b/auto_neutron/windows/gui/nearest_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 from PySide6 import QtCore, QtWidgets
 
 # noinspection PyUnresolvedReferences

--- a/auto_neutron/windows/gui/nearest_window.py
+++ b/auto_neutron/windows/gui/nearest_window.py
@@ -126,8 +126,6 @@ class NearestWindowGUI(QtWidgets.QDialog):
         for button in self.find_children(QtWidgets.QPushButton):
             button.auto_default = False
 
-        self.show()
-
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""
         self.system_name_label.text = _("System name")

--- a/auto_neutron/windows/gui/nearest_window.py
+++ b/auto_neutron/windows/gui/nearest_window.py
@@ -23,7 +23,7 @@ class NearestWindowGUI(QtWidgets.QDialog):
         self.main_layout = QtWidgets.QVBoxLayout(self)
         self.io_grid_layout = QtWidgets.QGridLayout()
 
-        self.system_name_label = QtWidgets.QLabel("System name", self)
+        self.system_name_label = QtWidgets.QLabel(self)
         self.system_name_label.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
@@ -33,28 +33,31 @@ class NearestWindowGUI(QtWidgets.QDialog):
         )
         self.system_name_result_label.cursor = QtCore.Qt.CursorShape.IBeamCursor
 
-        self.distance_label = QtWidgets.QLabel("Distance", self)
+        self.distance_label = QtWidgets.QLabel(self)
         self.distance_label.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
         self.distance_result_label = QtWidgets.QLabel(self)
 
         self.x_spinbox = QtWidgets.QDoubleSpinBox(self)
-        self.x_label = QtWidgets.QLabel("X", self)
+        # NOTE: Coordinate
+        self.x_label = QtWidgets.QLabel(self)
         self.x_label.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
         self.x_result_label = QtWidgets.QLabel(self)
 
         self.y_spinbox = QtWidgets.QDoubleSpinBox(self)
-        self.y_label = QtWidgets.QLabel("Y", self)
+        # NOTE: Coordinate
+        self.y_label = QtWidgets.QLabel(self)
         self.y_label.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
         self.y_result_label = QtWidgets.QLabel(self)
 
         self.z_spinbox = QtWidgets.QDoubleSpinBox(self)
-        self.z_label = QtWidgets.QLabel("Z", self)
+        # NOTE: Coordinate
+        self.z_label = QtWidgets.QLabel(self)
         self.z_label.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
@@ -68,27 +71,12 @@ class NearestWindowGUI(QtWidgets.QDialog):
                 QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
             )
 
-        self.from_location_button = QtWidgets.QPushButton("From location", self)
-        self.from_location_button.tool_tip = (
-            "Copy coordinates from the current location"
-        )
+        self.from_location_button = QtWidgets.QPushButton(self)
+        self.from_target_button = QtWidgets.QPushButton(self)
+        self.copy_to_source_button = QtWidgets.QPushButton(self)
+        self.copy_to_destination_button = QtWidgets.QPushButton(self)
 
-        self.from_target_button = QtWidgets.QPushButton("From target", self)
-        self.from_target_button.tool_tip = (
-            "Copy approximate coordinates from the current target"
-        )
-
-        self.copy_to_source_button = QtWidgets.QPushButton("To source", self)
-        self.copy_to_source_button.tool_tip = (
-            "Copy searched system name to the source input"
-        )
-
-        self.copy_to_destination_button = QtWidgets.QPushButton("To destination", self)
-        self.copy_to_source_button.tool_tip = (
-            "Copy searched system name to the destination input"
-        )
-
-        self.search_button = QtWidgets.QPushButton("Search", self)
+        self.search_button = QtWidgets.QPushButton(self)
 
         self.io_grid_layout.add_widget(self.system_name_label, 0, 0)
         self.io_grid_layout.add_widget(self.system_name_result_label, 0, 2)
@@ -139,3 +127,33 @@ class NearestWindowGUI(QtWidgets.QDialog):
             button.auto_default = False
 
         self.show()
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        self.system_name_label.text = _("System name")
+        self.distance_label.text = _("Distance")
+        # NOTE: Coordinate
+        self.x_label.text = _("X")
+        # NOTE: Coordinate
+        self.z_label.text = _("Y")
+        # NOTE: Coordinate
+        self.z_label.text = _("Z")
+
+        self.from_location_button.text = _("From location")
+        self.from_location_button.tool_tip = _(
+            "Copy coordinates from the current location"
+        )
+        self.from_target_button.text = _("From target")
+        self.from_target_button.tool_tip = _(
+            "Copy approximate coordinates from the current target"
+        )
+        self.copy_to_source_button.text = _("To source")
+        self.copy_to_source_button.tool_tip = _(
+            "Copy searched system name to the source input"
+        )
+        self.copy_to_destination_button.text = _("To destination")
+        self.copy_to_destination_button.tool_tip = _(
+            "Copy searched system name to the destination input"
+        )
+
+        self.search_button.text = _("Search")

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -101,7 +101,7 @@ class TabBase(QtWidgets.QWidget):
         self.journal_combo.add_items(
             [_("Last journal"), _("Second to last"), _("Third to last")]
         )
-        self.journal_combo.current_index = index
+        self.journal_combo.current_index = index if index != -1 else 0
 
 
 class NeutronTab(TabBase):

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -96,10 +96,12 @@ class TabBase(QtWidgets.QWidget):
             self.cargo_label.text = _("Cargo")
 
         self.submit_button.text = _("Submit")
+        index = self.journal_combo.current_index
         self.journal_combo.clear()
         self.journal_combo.add_items(
             [_("Last journal"), _("Second to last"), _("Third to last")]
         )
+        self.journal_combo.current_index = index
 
 
 class NeutronTab(TabBase):

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -48,14 +48,10 @@ class TabBase(QtWidgets.QWidget):
         journal_submit_layout = QtWidgets.QHBoxLayout()
 
         journal_combo = QtWidgets.QComboBox(widget_parent)
-        journal_combo.size_policy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
-        )
-        journal_combo.add_items(["Last journal", "Second to last", "Third to last"])
 
-        submit_button = QtWidgets.QPushButton("Submit", widget_parent)
+        submit_button = QtWidgets.QPushButton(widget_parent)
         submit_button.size_policy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum
         )
 
         journal_submit_layout.add_widget(
@@ -80,10 +76,7 @@ class TabBase(QtWidgets.QWidget):
         source_system_edit = QtWidgets.QLineEdit(parent)
         target_system_edit = QtWidgets.QLineEdit(parent)
 
-        source_system_edit.placeholder_text = "Source system"
-        target_system_edit.placeholder_text = "Destination system"
-
-        cargo_label = QtWidgets.QLabel("Cargo", parent)
+        cargo_label = QtWidgets.QLabel(parent)
         cargo_slider = TooltipSlider(QtCore.Qt.Orientation.Horizontal, parent)
 
         layout.add_widget(source_system_edit)
@@ -94,6 +87,20 @@ class TabBase(QtWidgets.QWidget):
 
         return layout, source_system_edit, target_system_edit, cargo_label, cargo_slider
 
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        if self.has_cargo:
+            self.source_edit.placeholder_text = _("Source system")
+            self.target_edit.placeholder_text = _("Destination system")
+
+            self.cargo_label.text = _("Cargo")
+
+        self.submit_button.text = _("Submit")
+        self.journal_combo.clear()
+        self.journal_combo.add_items(
+            [_("Last journal"), _("Second to last"), _("Third to last")]
+        )
+
 
 class NeutronTab(TabBase):
     """The neutron plotter tab."""
@@ -101,14 +108,14 @@ class NeutronTab(TabBase):
     def __init__(self, parent: QtWidgets.QWidget):
         super().__init__(parent, create_cargo=True)
 
-        self.range_label = QtWidgets.QLabel("Range", self)
+        self.range_label = QtWidgets.QLabel(self)
         self.range_spin = QtWidgets.QDoubleSpinBox(self)
         self.range_spin.accelerated = True
         self.range_spin.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
 
-        self.efficiency_label = QtWidgets.QLabel("Efficiency", self)
+        self.efficiency_label = QtWidgets.QLabel(self)
         self.efficiency_spin = QtWidgets.QSpinBox(self)
         self.efficiency_spin.maximum = 100
         self.efficiency_spin.suffix = "%"
@@ -118,7 +125,7 @@ class NeutronTab(TabBase):
         )
 
         self.eff_nearest_layout = QtWidgets.QHBoxLayout()
-        self.nearest_button = QtWidgets.QPushButton("Nearest", self)
+        self.nearest_button = QtWidgets.QPushButton(self)
         self.nearest_button.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
@@ -139,6 +146,13 @@ class NeutronTab(TabBase):
         self.main_layout.add_layout(self.eff_nearest_layout)
         self.main_layout.add_layout(self.journal_submit_layout)
 
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        super().retranslate()
+        self.range_label.text = _("Range")
+        self.efficiency_label.text = _("Efficiency")
+        self.nearest_button.text = _("Nearest")
+
 
 class ExactTab(TabBase):
     """The exact plotter tab."""
@@ -149,21 +163,15 @@ class ExactTab(TabBase):
             999  # static value because ship may come from outside source
         )
 
-        self.is_supercharged_checkbox = QtWidgets.QCheckBox(
-            "Already Supercharged", self
-        )
-        self.supercarge_checkbox = QtWidgets.QCheckBox("Use Supercharge", self)
-        self.fsd_injections_checkbox = QtWidgets.QCheckBox("Use FSD injections", self)
-        self.exclude_secondary_checkbox = QtWidgets.QCheckBox(
-            "Exclude secondary stars", self
-        )
+        self.is_supercharged_checkbox = QtWidgets.QCheckBox(self)
+        self.supercarge_checkbox = QtWidgets.QCheckBox(self)
+        self.fsd_injections_checkbox = QtWidgets.QCheckBox(self)
+        self.exclude_secondary_checkbox = QtWidgets.QCheckBox(self)
 
         self.use_clipboard_and_nearest_layout = QtWidgets.QHBoxLayout()
 
-        self.use_clipboard_checkbox = QtWidgets.QCheckBox(
-            "Use ship from clipboard", self
-        )
-        self.nearest_button = QtWidgets.QPushButton("Nearest", self)
+        self.use_clipboard_checkbox = QtWidgets.QCheckBox(self)
+        self.nearest_button = QtWidgets.QPushButton(self)
         self.nearest_button.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
@@ -185,6 +193,16 @@ class ExactTab(TabBase):
         self.main_layout.add_layout(self.use_clipboard_and_nearest_layout)
         self.main_layout.add_layout(self.journal_submit_layout)
 
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        super().retranslate()
+        self.is_supercharged_checkbox.text = _("Already supercharged")
+        self.supercarge_checkbox.text = _("Use supercharge")
+        self.fsd_injections_checkbox.text = _("Use FSD injections")
+        self.exclude_secondary_checkbox.text = _("Exclude secondary stars")
+        self.use_clipboard_checkbox.text = _("Use ship from clipboard")
+        self.nearest_button.text = _("Nearest")
+
 
 class CSVTab(TabBase):
     """The CSV plotter tab."""
@@ -195,7 +213,6 @@ class CSVTab(TabBase):
         self.path_layout = QtWidgets.QHBoxLayout()
 
         self.path_edit = QtWidgets.QLineEdit(self)
-        self.path_edit.placeholder_text = "CSV path"
 
         self.path_popup_button = QtWidgets.QPushButton("...", self)
         self.path_popup_button.maximum_width = 24
@@ -210,6 +227,11 @@ class CSVTab(TabBase):
             )
         )
         self.main_layout.add_layout(self.journal_submit_layout)
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        super().retranslate()
+        self.path_edit.placeholder_text = "CSV path"
 
 
 class LastTab(TabBase):
@@ -253,10 +275,10 @@ class NewRouteWindowGUI(QtWidgets.QDialog):
         self.spansh_exact_tab = ExactTab(self.tab_widget)
         self.last_route_tab = LastTab(self.tab_widget)
 
-        self.tab_widget.add_tab(self.csv_tab, "CSV")
-        self.tab_widget.add_tab(self.spansh_neutron_tab, "Neutron plotter")
-        self.tab_widget.add_tab(self.spansh_exact_tab, "Galaxy plotter")
-        self.tab_widget.add_tab(self.last_route_tab, "Saved route")
+        self.tab_widget.add_tab(self.csv_tab, "")
+        self.tab_widget.add_tab(self.spansh_neutron_tab, "")
+        self.tab_widget.add_tab(self.spansh_exact_tab, "")
+        self.tab_widget.add_tab(self.last_route_tab, "")
 
         self.status_bar = QtWidgets.QStatusBar(self)
 
@@ -266,4 +288,15 @@ class NewRouteWindowGUI(QtWidgets.QDialog):
         for button in self.find_children(QtWidgets.QPushButton):
             button.auto_default = False
 
-        self.show()
+        self.csv_tab.journal_combo.adjust_size()
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        self.csv_tab.retranslate()
+        self.spansh_neutron_tab.retranslate()
+        self.spansh_exact_tab.retranslate()
+        self.last_route_tab.retranslate()
+        self.tab_widget.set_tab_text(0, _("CSV"))
+        self.tab_widget.set_tab_text(1, _("Neutron plotter"))
+        self.tab_widget.set_tab_text(2, _("Galaxy plotter"))
+        self.tab_widget.set_tab_text(3, _("Saved route"))

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -234,6 +234,14 @@ class LastTab(TabBase):
             self.submit_button,
         ) = self.create_journal_and_submit_layout(self)
 
+        self.source_label = QtWidgets.QLabel(self)
+        self.location_label = QtWidgets.QLabel(self)
+        self.destination_label = QtWidgets.QLabel(self)
+
+        self.main_layout.add_widget(self.source_label)
+        self.main_layout.add_widget(self.location_label)
+        self.main_layout.add_widget(self.destination_label)
+
         self.main_layout.add_spacer_item(
             QtWidgets.QSpacerItem(
                 1, 1, QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Expanding

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -9,6 +9,7 @@ from PySide6 import QtCore, QtWidgets
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa F401
+from auto_neutron.utils.forbid_uninitialized import ForbidUninitialized
 
 from .tooltip_slider import TooltipSlider
 
@@ -16,9 +17,29 @@ from .tooltip_slider import TooltipSlider
 class TabBase(QtWidgets.QWidget):
     """Provide the base for a tab with convenience methods."""
 
-    def __init__(self, parent: QtWidgets.QWidget):
+    system_cargo_layout = ForbidUninitialized()
+    source_edit = ForbidUninitialized()
+    target_edit = ForbidUninitialized()
+    cargo_label = ForbidUninitialized()
+    cargo_slider = ForbidUninitialized()
+
+    def __init__(self, parent: QtWidgets.QWidget, *, create_cargo: bool):
         super().__init__(parent)
         self.main_layout = QtWidgets.QVBoxLayout(self)
+        self.has_cargo = create_cargo
+        if create_cargo:
+            (
+                self.system_cargo_layout,
+                self.source_edit,
+                self.target_edit,
+                self.cargo_label,
+                self.cargo_slider,
+            ) = self.create_system_and_cargo_layout(self)
+        (
+            self.journal_submit_layout,
+            self.journal_combo,
+            self.submit_button,
+        ) = self.create_journal_and_submit_layout(self)
 
     def create_journal_and_submit_layout(
         self, widget_parent: QtWidgets.QWidget
@@ -78,14 +99,7 @@ class NeutronTab(TabBase):
     """The neutron plotter tab."""
 
     def __init__(self, parent: QtWidgets.QWidget):
-        super().__init__(parent)
-        (
-            self.system_cargo_layout,
-            self.source_edit,
-            self.target_edit,
-            self.cargo_label,
-            self.cargo_slider,
-        ) = self.create_system_and_cargo_layout(self)
+        super().__init__(parent, create_cargo=True)
 
         self.range_label = QtWidgets.QLabel("Range", self)
         self.range_spin = QtWidgets.QDoubleSpinBox(self)
@@ -113,12 +127,6 @@ class NeutronTab(TabBase):
         )
         self.eff_nearest_layout.add_widget(self.nearest_button)
 
-        (
-            self.journal_submit_layout,
-            self.journal_combo,
-            self.submit_button,
-        ) = self.create_journal_and_submit_layout(self)
-
         self.main_layout.add_layout(self.system_cargo_layout)
         self.main_layout.add_spacer_item(
             QtWidgets.QSpacerItem(
@@ -136,15 +144,7 @@ class ExactTab(TabBase):
     """The exact plotter tab."""
 
     def __init__(self, parent: QtWidgets.QWidget):
-        super().__init__(parent)
-        (
-            self.system_cargo_layout,
-            self.source_edit,
-            self.target_edit,
-            self.cargo_label,
-            self.cargo_slider,
-        ) = self.create_system_and_cargo_layout(self)
-
+        super().__init__(parent, create_cargo=True)
         self.cargo_slider.maximum = (
             999  # static value because ship may come from outside source
         )
@@ -172,12 +172,6 @@ class ExactTab(TabBase):
         )
         self.use_clipboard_and_nearest_layout.add_widget(self.nearest_button)
 
-        (
-            self.journal_submit_layout,
-            self.journal_combo,
-            self.submit_button,
-        ) = self.create_journal_and_submit_layout(self)
-
         self.main_layout.add_layout(self.system_cargo_layout)
         self.main_layout.add_spacer_item(
             QtWidgets.QSpacerItem(
@@ -196,7 +190,7 @@ class CSVTab(TabBase):
     """The CSV plotter tab."""
 
     def __init__(self, parent: QtWidgets.QWidget):
-        super().__init__(parent)
+        super().__init__(parent, create_cargo=False)
 
         self.path_layout = QtWidgets.QHBoxLayout()
 
@@ -208,12 +202,6 @@ class CSVTab(TabBase):
 
         self.path_layout.add_widget(self.path_edit)
         self.path_layout.add_widget(self.path_popup_button)
-
-        (
-            self.journal_submit_layout,
-            self.journal_combo,
-            self.submit_button,
-        ) = self.create_journal_and_submit_layout(self)
 
         self.main_layout.add_layout(self.path_layout)
         self.main_layout.add_spacer_item(
@@ -228,13 +216,7 @@ class LastTab(TabBase):
     """The last route plot tab."""
 
     def __init__(self, parent: QtWidgets.QWidget):
-        super().__init__(parent)
-
-        (
-            self.journal_submit_layout,
-            self.journal_combo,
-            self.submit_button,
-        ) = self.create_journal_and_submit_layout(self)
+        super().__init__(parent, create_cargo=False)
 
         self.source_label = QtWidgets.QLabel(self)
         self.location_label = QtWidgets.QLabel(self)

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import typing as t
 
 from PySide6 import QtCore, QtWidgets

--- a/auto_neutron/windows/gui/settings_window.py
+++ b/auto_neutron/windows/gui/settings_window.py
@@ -10,6 +10,22 @@ from PySide6 import QtCore, QtWidgets
 from __feature__ import snake_case, true_property  # noqa: F401
 
 
+class _ReorderedCheckBox(QtWidgets.QCheckBox):
+    """Checkbox with check states reordered so the partial state appears after both unchecked and checked."""
+
+    _CHECK_STATES = [
+        QtCore.Qt.CheckState.Unchecked,
+        QtCore.Qt.CheckState.Checked,
+        QtCore.Qt.CheckState.PartiallyChecked,
+    ]
+
+    def next_check_state(self) -> None:
+        """Set the next state."""
+        self.set_check_state(
+            self._CHECK_STATES[(self._CHECK_STATES.index(self.check_state()) + 1) % 3]
+        )
+
+
 class SettingsWindowGUI(QtWidgets.QDialog):
     """Implement the basic settings GUI with multiple settings categories from the settings module."""
 
@@ -76,9 +92,10 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         self.font_chooser = QtWidgets.QFontComboBox(self.appearance_widget)
         self.font_size_chooser = QtWidgets.QSpinBox(self.appearance_widget)
         self.font_bold_checkbox = QtWidgets.QCheckBox("Bold", self.appearance_widget)
-        self.dark_mode_checkbox = QtWidgets.QCheckBox(
+        self.dark_mode_checkbox = _ReorderedCheckBox(
             "Dark mode", self.appearance_widget
         )
+        self.dark_mode_checkbox.tristate = True
 
         self.font_layout = QtWidgets.QHBoxLayout()
         self.font_layout.add_widget(self.font_chooser)

--- a/auto_neutron/windows/gui/settings_window.py
+++ b/auto_neutron/windows/gui/settings_window.py
@@ -174,8 +174,6 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         for button in self.find_children(QtWidgets.QPushButton):
             button.auto_default = False
 
-        self.show()
-
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""
         self.ok_button.text = _("Ok")

--- a/auto_neutron/windows/gui/settings_window.py
+++ b/auto_neutron/windows/gui/settings_window.py
@@ -189,10 +189,12 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         """Retranslate text that is always on display."""
         self.ok_button.text = _("Ok")
         self.apply_button.text = _("Apply")
+        index = self.group_selector.current_index()
         self.group_selector.clear()
         self.group_selector.add_items(
             (_("Appearance"), _("Behaviour"), _("Alerts"), _("AHK script"))
         )
+        self.group_selector.set_current_index(index)
         self.group_selector.set_fixed_width(
             self.group_selector.size_hint_for_column(0) + 5
         )

--- a/auto_neutron/windows/gui/settings_window.py
+++ b/auto_neutron/windows/gui/settings_window.py
@@ -54,8 +54,8 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         # region main view
         self.group_selector = QtWidgets.QListWidget(self)
         self.widget_selector = QtWidgets.QStackedWidget(self)
-        self.ok_button = QtWidgets.QPushButton("Ok", self)
-        self.apply_button = QtWidgets.QPushButton("Apply", self)
+        self.ok_button = QtWidgets.QPushButton(self)
+        self.apply_button = QtWidgets.QPushButton(self)
         self.error_label = QtWidgets.QLabel(self)
         # region main layout init
         self.main_bottom_layout.add_widget(self.error_label)
@@ -77,14 +77,8 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         self.widget_selector.add_widget(self.alerts_widget)
         self.widget_selector.add_widget(self.script_widget)
 
-        self.group_selector.add_items(
-            ("Appearance", "Behaviour", "Alerts", "AHK script")
-        )
         self.group_selector.horizontal_scroll_bar_policy = (
             QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
-        )
-        self.group_selector.set_fixed_width(
-            self.group_selector.size_hint_for_column(0) + 5
         )
 
         self.ok_button.maximum_width = 75
@@ -93,10 +87,8 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         # region appearance group
         self.font_chooser = QtWidgets.QFontComboBox(self.appearance_widget)
         self.font_size_chooser = QtWidgets.QSpinBox(self.appearance_widget)
-        self.font_bold_checkbox = QtWidgets.QCheckBox("Bold", self.appearance_widget)
-        self.dark_mode_checkbox = _ReorderedCheckBox(
-            "Dark mode", self.appearance_widget
-        )
+        self.font_bold_checkbox = QtWidgets.QCheckBox(self.appearance_widget)
+        self.dark_mode_checkbox = _ReorderedCheckBox(self.appearance_widget)
         self.dark_mode_checkbox.tristate = True
 
         self.font_layout = QtWidgets.QHBoxLayout()
@@ -112,16 +104,10 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         # region behaviour group
         self.plotter_options_layout = QtWidgets.QHBoxLayout()
 
-        self.save_on_quit_checkbox = QtWidgets.QCheckBox(
-            "Save route on window close", self.behaviour_widget
-        )
-        self.copy_mode_checkbox = QtWidgets.QCheckBox(
-            "Copy mode", self.behaviour_widget
-        )
-        self.ahk_path_button = QtWidgets.QPushButton("AHK Path", self.behaviour_widget)
-        self.auto_scroll_checkbox = QtWidgets.QCheckBox(
-            "Auto scroll", self.behaviour_widget
-        )
+        self.save_on_quit_checkbox = QtWidgets.QCheckBox(self.behaviour_widget)
+        self.copy_mode_checkbox = QtWidgets.QCheckBox(self.behaviour_widget)
+        self.ahk_path_button = QtWidgets.QPushButton(self.behaviour_widget)
+        self.auto_scroll_checkbox = QtWidgets.QCheckBox(self.behaviour_widget)
 
         self.plotter_options_layout.add_widget(self.copy_mode_checkbox)
         self.plotter_options_layout.add_widget(self.ahk_path_button)
@@ -137,21 +123,14 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         self.alert_path_layout = QtWidgets.QHBoxLayout()
         self.alert_threshold_layout = QtWidgets.QHBoxLayout()
 
-        self.visual_alert_checkbox = QtWidgets.QCheckBox(
-            "Taskbar fuel alert", self.alerts_widget
-        )
-        self.audio_alert_checkbox = QtWidgets.QCheckBox(
-            "Sound fuel alert", self.alerts_widget
-        )
+        self.visual_alert_checkbox = QtWidgets.QCheckBox(self.alerts_widget)
+        self.audio_alert_checkbox = QtWidgets.QCheckBox(self.alerts_widget)
 
-        self.alert_path_label = QtWidgets.QLabel(
-            "Custom sound alert file:", self.alerts_widget
-        )
+        self.alert_path_label = QtWidgets.QLabel(self.alerts_widget)
         self.alert_path_line_edit = QtWidgets.QLineEdit(self.alerts_widget)
         self.alert_path_button = QtWidgets.QPushButton("...", self.alerts_widget)
 
         self.alert_threshold_label = QtWidgets.QLabel(
-            "% of maximum fuel usage left in tank before triggering alert",
             self.alerts_widget,
         )
         self.alert_threshold_spinbox = QtWidgets.QSpinBox(self.alerts_widget)
@@ -181,7 +160,6 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         self.script_layout.add_widget(self.ahk_script_edit)
 
         self.ahk_bind_edit.maximum_width = 100
-        self.ahk_bind_edit.tool_tip = "Bind to trigger the script, # for win key, ! for alt, ^ for control, + for shift"
         self.alert_threshold_spinbox.maximum = 300
         self.alert_threshold_spinbox.accelerated = True
         self.alert_threshold_spinbox.maximum_width = 75
@@ -189,7 +167,6 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         self.alert_threshold_label.word_wrap = True
 
         # endregion
-        self.window_title = "Settings"
         self.group_selector.currentRowChanged.connect(
             partial(setattr, self.widget_selector, "current_index")
         )
@@ -198,6 +175,38 @@ class SettingsWindowGUI(QtWidgets.QDialog):
             button.auto_default = False
 
         self.show()
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        self.ok_button.text = _("Ok")
+        self.apply_button.text = _("Apply")
+        self.group_selector.clear()
+        self.group_selector.add_items(
+            (_("Appearance"), _("Behaviour"), _("Alerts"), _("AHK script"))
+        )
+        self.group_selector.set_fixed_width(
+            self.group_selector.size_hint_for_column(0) + 5
+        )
+
+        self.font_bold_checkbox.text = _("Bold")
+        self.dark_mode_checkbox.text = _("Dark mode")
+
+        self.save_on_quit_checkbox.text = _("Save route on window close")
+        self.copy_mode_checkbox.text = _("Copy Mode")
+        self.ahk_path_button.text = _("AHK Path")
+        self.auto_scroll_checkbox.text = _("Auto scroll")
+
+        self.visual_alert_checkbox.text = _("Taskbar fuel alert")
+        self.audio_alert_checkbox.text = _("Sound fuel alert")
+        self.alert_path_label.text = _("Custom sound alert file:")
+        self.alert_threshold_label.text = _(
+            "% of maximum fuel usage left in tank before triggering alert"
+        )
+
+        self.window_title = _("Settings")
+        self.ahk_bind_edit.tool_tip = _(
+            "Bind to trigger the script, # for win key, ! for alt, ^ for control, + for shift"
+        )
 
     def get_spacer(self) -> QtWidgets.QSpacerItem:
         """Get an expanding spacer item."""

--- a/auto_neutron/windows/gui/settings_window.py
+++ b/auto_neutron/windows/gui/settings_window.py
@@ -200,7 +200,7 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         # Escape % for translation
         self.alert_threshold_label.text = _(
             "%% of maximum fuel usage left in tank before triggering alert"
-        )
+        ).replace("%%", "%")
 
         self.window_title = _("Settings")
         self.ahk_bind_edit.tool_tip = _(

--- a/auto_neutron/windows/gui/settings_window.py
+++ b/auto_neutron/windows/gui/settings_window.py
@@ -197,8 +197,9 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         self.visual_alert_checkbox.text = _("Taskbar fuel alert")
         self.audio_alert_checkbox.text = _("Sound fuel alert")
         self.alert_path_label.text = _("Custom sound alert file:")
+        # Escape % for translation
         self.alert_threshold_label.text = _(
-            "% of maximum fuel usage left in tank before triggering alert"
+            "%% of maximum fuel usage left in tank before triggering alert"
         )
 
         self.window_title = _("Settings")

--- a/auto_neutron/windows/gui/settings_window.py
+++ b/auto_neutron/windows/gui/settings_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import typing as t
 from functools import partial
 

--- a/auto_neutron/windows/gui/settings_window.py
+++ b/auto_neutron/windows/gui/settings_window.py
@@ -88,13 +88,24 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         self.font_chooser = QtWidgets.QFontComboBox(self.appearance_widget)
         self.font_size_chooser = QtWidgets.QSpinBox(self.appearance_widget)
         self.font_bold_checkbox = QtWidgets.QCheckBox(self.appearance_widget)
+
+        self.language_label = QtWidgets.QLabel(self)
+        self.language_combo = QtWidgets.QComboBox(self)
+        self.language_combo.size_adjust_policy = (
+            QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToContents
+        )
+
         self.dark_mode_checkbox = _ReorderedCheckBox(self.appearance_widget)
         self.dark_mode_checkbox.tristate = True
 
         self.font_layout = QtWidgets.QHBoxLayout()
         self.font_layout.add_widget(self.font_chooser)
         self.font_layout.add_widget(self.font_size_chooser)
+        self.language_layout = QtWidgets.QHBoxLayout()
+        self.language_layout.add_widget(self.language_label)
+        self.language_layout.add_widget(self.language_combo)
         self.appearance_layout.add_layout(self.font_layout)
+        self.appearance_layout.add_layout(self.language_layout)
         self.appearance_layout.add_widget(self.font_bold_checkbox)
         self.appearance_layout.add_widget(self.dark_mode_checkbox)
         self.appearance_layout.add_spacer_item(self.get_spacer())
@@ -187,6 +198,7 @@ class SettingsWindowGUI(QtWidgets.QDialog):
         )
 
         self.font_bold_checkbox.text = _("Bold")
+        self.language_label.text = _("Language")
         self.dark_mode_checkbox.text = _("Dark mode")
 
         self.save_on_quit_checkbox.text = _("Save route on window close")

--- a/auto_neutron/windows/gui/shut_down_window.py
+++ b/auto_neutron/windows/gui/shut_down_window.py
@@ -65,10 +65,12 @@ class ShutDownWindowGUI(QtWidgets.QDialog):
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""
         self.info_label.text = _("Game shut down")
+        index = self.journal_combo.current_index
         self.journal_combo.clear()
         self.journal_combo.add_items(
             [_("Last journal"), _("Second to last"), _("Third to last")]
         )
+        self.journal_combo.current_index = index
         self.new_journal_button.text = _("New journal")
         self.save_route_button.text = _("Save route")
         self.quit_button.text = _("Quit")

--- a/auto_neutron/windows/gui/shut_down_window.py
+++ b/auto_neutron/windows/gui/shut_down_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 from PySide6 import QtCore, QtGui, QtWidgets
 
 # noinspection PyUnresolvedReferences

--- a/auto_neutron/windows/gui/shut_down_window.py
+++ b/auto_neutron/windows/gui/shut_down_window.py
@@ -16,29 +16,27 @@ class ShutDownWindowGUI(QtWidgets.QDialog):
         super().__init__(parent)
         self.set_attribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
 
-        self.info_label = QtWidgets.QLabel("Game shut down", self)
+        self.info_label = QtWidgets.QLabel(self)
         font = QtGui.QFont()
         font.set_point_size(18)
         self.info_label.font = font
 
         self.journal_combo = QtWidgets.QComboBox(self)
-        self.journal_combo.add_items(
-            ["Last journal", "Second to last", "Third to last"]
-        )
+
         self.journal_combo.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
 
-        self.new_journal_button = QtWidgets.QPushButton("New journal", self)
+        self.new_journal_button = QtWidgets.QPushButton(self)
         self.new_journal_button.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
 
-        self.save_route_button = QtWidgets.QPushButton("Save route", self)
+        self.save_route_button = QtWidgets.QPushButton(self)
         self.save_route_button.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
-        self.quit_button = QtWidgets.QPushButton("Quit", self)
+        self.quit_button = QtWidgets.QPushButton(self)
         self.quit_button.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
         )
@@ -65,3 +63,14 @@ class ShutDownWindowGUI(QtWidgets.QDialog):
         self.main_layout.add_layout(self.button_layout)
 
         self.show()
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        self.info_label.text = _("Game shut down")
+        self.journal_combo.clear()
+        self.journal_combo.add_items(
+            [_("Last journal"), _("Second to last"), _("Third to last")]
+        )
+        self.new_journal_button.text = _("New journal")
+        self.save_route_button.text = _("Save route")
+        self.quit_button.text = _("Quit")

--- a/auto_neutron/windows/gui/shut_down_window.py
+++ b/auto_neutron/windows/gui/shut_down_window.py
@@ -70,7 +70,7 @@ class ShutDownWindowGUI(QtWidgets.QDialog):
         self.journal_combo.add_items(
             [_("Last journal"), _("Second to last"), _("Third to last")]
         )
-        self.journal_combo.current_index = index
+        self.journal_combo.current_index = index if index != -1 else 0
         self.new_journal_button.text = _("New journal")
         self.save_route_button.text = _("Save route")
         self.quit_button.text = _("Quit")

--- a/auto_neutron/windows/gui/shut_down_window.py
+++ b/auto_neutron/windows/gui/shut_down_window.py
@@ -62,8 +62,6 @@ class ShutDownWindowGUI(QtWidgets.QDialog):
         )
         self.main_layout.add_layout(self.button_layout)
 
-        self.show()
-
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""
         self.info_label.text = _("Game shut down")

--- a/auto_neutron/windows/gui/tooltip_slider.py
+++ b/auto_neutron/windows/gui/tooltip_slider.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 from functools import partial
 
 from PySide6 import QtCore, QtGui, QtWidgets

--- a/auto_neutron/windows/gui/tooltip_slider.py
+++ b/auto_neutron/windows/gui/tooltip_slider.py
@@ -110,7 +110,7 @@ class TooltipSlider(QtWidgets.QSlider):
     def mouse_move_event(self, event: QtGui.QMouseEvent) -> None:
         """Show the value tooltip on hover."""
         super().mouse_move_event(event)
-        on_handle = self._handle_rect().contains(event.pos())
+        on_handle = self._handle_rect().contains(event.position().to_point())
 
         if on_handle and not self._mouse_on_handle:
             self._mouse_on_handle = True

--- a/auto_neutron/windows/main_window.py
+++ b/auto_neutron/windows/main_window.py
@@ -142,6 +142,11 @@ class MainWindow(MainWindowGUI):
         """Save size and position to settings."""
         settings.Window.geometry = self.save_geometry()
 
+    def change_event(self, event: QtCore.QEvent) -> None:
+        """Retranslate the GUI when a language change occurs."""
+        if event.type() == QtCore.QEvent.LanguageChange:
+            self.retranslate()
+
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""
         super().retranslate()

--- a/auto_neutron/windows/main_window.py
+++ b/auto_neutron/windows/main_window.py
@@ -109,7 +109,7 @@ class MainWindow(MainWindowGUI):
         with self.resize_connection.temporarily_disconnect():
             if self._current_route_type is ExactPlotRow:
                 self.table.horizontal_header_item(0).set_text(
-                    f"System name ({index+1}/{self.table.row_count})"
+                    "System name ({}/{})".format(index + 1, self.table.row_count)
                 )
             else:
                 total_jumps = sum(
@@ -121,7 +121,7 @@ class MainWindow(MainWindowGUI):
                     for row in range(index, self.table.row_count)
                 )
                 self.table.horizontal_header_item(3).set_text(
-                    f"Jumps {remaining_jumps}/{total_jumps}"
+                    "Jumps {}/{}".format(remaining_jumps, total_jumps)
                 )
         self.table.resize_column_to_contents(0)
         self.table.resize_column_to_contents(3)

--- a/auto_neutron/windows/main_window.py
+++ b/auto_neutron/windows/main_window.py
@@ -1,8 +1,9 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import atexit
-import collections.abc
 import dataclasses
 import typing as t
 
@@ -11,10 +12,15 @@ from PySide6 import QtCore, QtWidgets
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron import settings
-from auto_neutron.route_plots import ExactPlotRow, NeutronPlotRow, RouteList
+from auto_neutron.route_plots import ExactPlotRow, NeutronPlotRow
 from auto_neutron.utils.signal import ReconnectingSignal
 
 from .gui.main_window import MainWindowGUI
+
+if t.TYPE_CHECKING:
+    import collections.abc
+
+    from auto_neutron.route_plots import RouteList
 
 
 class MainWindow(MainWindowGUI):

--- a/auto_neutron/windows/missing_journal_window.py
+++ b/auto_neutron/windows/missing_journal_window.py
@@ -17,3 +17,4 @@ class MissingJournalWindow(MissingJournalWindowGUI):
         super().__init__(parent)
 
         self.quit_button.pressed.connect(QtWidgets.QApplication.instance().quit)
+        self.retranslate()

--- a/auto_neutron/windows/missing_journal_window.py
+++ b/auto_neutron/windows/missing_journal_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 from PySide6 import QtWidgets
 
 # noinspection PyUnresolvedReferences

--- a/auto_neutron/windows/missing_journal_window.py
+++ b/auto_neutron/windows/missing_journal_window.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from PySide6 import QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
@@ -18,3 +18,8 @@ class MissingJournalWindow(MissingJournalWindowGUI):
 
         self.quit_button.pressed.connect(QtWidgets.QApplication.instance().quit)
         self.retranslate()
+
+    def change_event(self, event: QtCore.QEvent) -> None:
+        """Retranslate the GUI when a language change occurs."""
+        if event.type() == QtCore.QEvent.LanguageChange:
+            self.retranslate()

--- a/auto_neutron/windows/nearest_window.py
+++ b/auto_neutron/windows/nearest_window.py
@@ -28,6 +28,7 @@ class NearestWindow(NearestWindowGUI):
         super().__init__(parent)
         self.set_input_values_from_location(start_location)
         self.search_button.pressed.connect(self._make_nearest_request)
+        self.retranslate()
 
     def set_input_values_from_location(self, location: t.Optional[Location]) -> None:
         """Set the input spinboxes to x, y, z."""

--- a/auto_neutron/windows/nearest_window.py
+++ b/auto_neutron/windows/nearest_window.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from PySide6 import QtNetwork, QtWidgets
+from PySide6 import QtCore, QtNetwork, QtWidgets
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa F401
@@ -68,3 +68,8 @@ class NearestWindow(NearestWindowGUI):
         self.z_result_label.text = (
             format(data["system"]["z"], ".2f").rstrip("0").rstrip(".")
         )
+
+    def change_event(self, event: QtCore.QEvent) -> None:
+        """Retranslate the GUI when a language change occurs."""
+        if event.type() == QtCore.QEvent.LanguageChange:
+            self.retranslate()

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -431,6 +431,11 @@ class NewRouteWindow(NewRouteWindowGUI):
         self.route_created_signal.emit(journal, route, route_index)
         self.close()
 
+    def change_event(self, event: QtCore.QEvent) -> None:
+        """Retranslate the GUI when a language change occurs."""
+        if event.type() == QtCore.QEvent.LanguageChange:
+            self.retranslate()
+
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""
         exit_stack = contextlib.ExitStack()

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -126,7 +126,6 @@ class NewRouteWindow(NewRouteWindowGUI):
         self._loaded_route: t.Optional[list[NeutronPlotRow]] = None
         self.retranslate()
         self._change_journal(0)
-        self.show()
 
     # region spansh plotters
     def _submit_neutron(self) -> None:
@@ -276,6 +275,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         window.from_location_button.pressed.connect(
             lambda: window.set_input_values_from_location(self.game_state.location)
         )
+        window.show()
 
     def _set_line_edits_from_nearest(
         self, *line_edits: QtWidgets.QLineEdit, window: NearestWindow

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -315,7 +315,7 @@ class NewRouteWindow(NewRouteWindowGUI):
     def _route_from_csv(self, path: Path) -> t.Optional[RouteList]:
         try:
             with path.open(encoding="utf8") as csv_file:
-                reader = csv.reader(csv_file)
+                reader = csv.reader(csv_file, strict=True)
                 header = next(reader)
                 if len(header) == 5:
                     row_type = NeutronPlotRow

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -411,7 +411,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         self.game_state.connect_journal(journal)
         if self._journal_worker is not None:
             self._journal_worker.stop()
-        self._journal_worker = GameWorker([], journal)
+        self._journal_worker = GameWorker(self, [], journal)
         self._journal_worker.start()
 
         if loadout is not None and location is not None and cargo_mass is not None:

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import contextlib
 import csv
 import json
@@ -20,13 +22,11 @@ from auto_neutron.constants import (
     SPANSH_API_URL,
     get_config_dir,
 )
-from auto_neutron.game_state import Location
 from auto_neutron.hub import GameState
 from auto_neutron.journal import Journal
 from auto_neutron.route_plots import (
     ExactPlotRow,
     NeutronPlotRow,
-    RouteList,
     spansh_exact_callback,
     spansh_neutron_callback,
 )
@@ -39,6 +39,9 @@ from auto_neutron.workers import GameWorker
 from .gui.new_route_window import NewRouteWindowGUI
 from .nearest_window import NearestWindow
 
+if t.TYPE_CHECKING:
+    from auto_neutron.game_state import Location
+    from auto_neutron.route_plots import RouteList
 log = logging.getLogger(__name__)
 
 

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -31,6 +31,7 @@ from auto_neutron.route_plots import (
     spansh_neutron_callback,
 )
 from auto_neutron.ship import Ship
+from auto_neutron.utils.forbid_uninitialized import ForbidUninitialized
 from auto_neutron.utils.network import make_network_request
 from auto_neutron.utils.signal import ReconnectingSignal
 from auto_neutron.utils.utils import create_request_delay_iterator
@@ -49,12 +50,14 @@ class NewRouteWindow(NewRouteWindowGUI):
     """The UI for plotting a new route, from CSV, Spansh plotters, or the last saved route."""
 
     route_created_signal = QtCore.Signal(Journal, list, int)
+    game_state = ForbidUninitialized()
+    selected_journal = ForbidUninitialized()
 
     def __init__(self, parent: QtWidgets.QWidget):
         super().__init__(parent)
-        self.game_state: t.Optional[GameState] = None
-        self.selected_journal: t.Optional[Journal] = None
-        self._journal_worker: t.Optional[GameWorker] = None
+        self.game_state: GameState = None  # type: ignore
+        self.selected_journal: Journal = None  # type: ignore
+        self._journal_worker: GameWorker = None  # type: ignore
 
         # region spansh tabs init
         self.spansh_neutron_tab.nearest_button.pressed.connect(

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -348,15 +348,15 @@ class NewRouteWindow(NewRouteWindowGUI):
                 get_config_dir() / ROUTE_FILE_NAME
             )
             if self._loaded_route is not None:
-                self.last_route_tab.source_label.text = (
-                    f"Source: {self._loaded_route[0].system}"
+                self.last_route_tab.source_label.text = "Source: {}".format(
+                    self._loaded_route[0].system
                 )
                 self.last_route_tab.location_label.text = (
-                    f"Saved location: "
-                    f"{self._loaded_route[settings.General.last_route_index].system}"
+                    "Saved location: "
+                    + self._loaded_route[settings.General.last_route_index].system
                 )
-                self.last_route_tab.destination_label.text = (
-                    f"Destination: {self._loaded_route[-1].system}"
+                self.last_route_tab.destination_label.text = "Destination: {}".format(
+                    self._loaded_route[-1].system
                 )
 
     def _last_route_submit(self) -> None:

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -216,17 +216,15 @@ class NewRouteWindow(NewRouteWindowGUI):
 
         self.spansh_exact_tab.cargo_slider.value = current_cargo
 
-        if self.game_state.ship.fsd is not None:
-            self.spansh_neutron_tab.range_spin.value = ship.jump_range(
-                cargo_mass=current_cargo
-            )
+        self.spansh_neutron_tab.range_spin.value = ship.jump_range(
+            cargo_mass=current_cargo
+        )
 
     def _recalculate_range(self, cargo_mass: int) -> None:
         """Recalculate jump range with the new cargo_mass."""
-        if self.game_state.ship.fsd is not None:
-            self.spansh_neutron_tab.range_spin.value = self.game_state.ship.jump_range(
-                cargo_mass=cargo_mass
-            )
+        self.spansh_neutron_tab.range_spin.value = self.game_state.ship.jump_range(
+            cargo_mass=cargo_mass
+        )
 
     def _set_neutron_submit(self) -> None:
         """Enable the neutron submit button if both inputs are filled, disable otherwise."""

--- a/auto_neutron/windows/settings_window.py
+++ b/auto_neutron/windows/settings_window.py
@@ -14,6 +14,7 @@ from PySide6 import QtCore, QtWidgets
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron import settings
 from auto_neutron.constants import AHK_PATH
+from auto_neutron.locale import code_from_locale, get_available_locales
 from auto_neutron.settings import delay_sync
 from auto_neutron.windows.gui.settings_window import SettingsWindowGUI
 
@@ -128,6 +129,21 @@ class SettingsWindow(SettingsWindowGUI):
             font.set_point_size(self.font_size_chooser.value)
             font.set_bold(self.font_bold_checkbox.checked)
             settings.Window.font = font
+
+            settings.General.locale = code_from_locale(
+                get_available_locales()[self.language_combo.current_index]
+            )
+
+    def retranslate(self) -> None:
+        """Retranslate text that is always on display."""
+        super().retranslate()
+        self.language_combo.clear()
+        locales = get_available_locales()
+        language_codes = [code_from_locale(locale) for locale in locales]
+        self.language_combo.add_items([locale.get_display_name() for locale in locales])
+        self.language_combo.current_index = language_codes.index(
+            settings.General.locale
+        )
 
     def change_event(self, event: QtCore.QEvent) -> None:
         """Retranslate the GUI when a language change occurs."""

--- a/auto_neutron/windows/settings_window.py
+++ b/auto_neutron/windows/settings_window.py
@@ -83,7 +83,7 @@ class SettingsWindow(SettingsWindowGUI):
         for widget, (setting_group, setting_name) in self.settings_pairs:
             setting_value = attrgetter(f"{setting_group}.{setting_name}")(settings)
             if isinstance(widget, QtWidgets.QCheckBox):
-                widget.checked = setting_value
+                widget.set_check_state(QtCore.Qt.CheckState(setting_value))
             elif isinstance(widget, QtWidgets.QLineEdit):
                 widget.text = (
                     str(setting_value) if setting_value is not None else ""
@@ -104,7 +104,7 @@ class SettingsWindow(SettingsWindowGUI):
             for widget, (setting_group, setting_name) in self.settings_pairs:
                 settings_category = getattr(settings, setting_group)
                 if isinstance(widget, QtWidgets.QCheckBox):
-                    setattr(settings_category, setting_name, widget.checked)
+                    setattr(settings_category, setting_name, int(widget.check_state()))
                 elif isinstance(widget, QtWidgets.QLineEdit):
                     setattr(settings_category, setting_name, widget.text)
                 elif isinstance(widget, QtWidgets.QTextEdit):

--- a/auto_neutron/windows/settings_window.py
+++ b/auto_neutron/windows/settings_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 import logging
 import typing as t
 from operator import attrgetter

--- a/auto_neutron/windows/settings_window.py
+++ b/auto_neutron/windows/settings_window.py
@@ -128,3 +128,8 @@ class SettingsWindow(SettingsWindowGUI):
             font.set_point_size(self.font_size_chooser.value)
             font.set_bold(self.font_bold_checkbox.checked)
             settings.Window.font = font
+
+    def change_event(self, event: QtCore.QEvent) -> None:
+        """Retranslate the GUI when a language change occurs."""
+        if event.type() == QtCore.QEvent.LanguageChange:
+            self.retranslate()

--- a/auto_neutron/windows/settings_window.py
+++ b/auto_neutron/windows/settings_window.py
@@ -14,7 +14,7 @@ from PySide6 import QtCore, QtWidgets
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron import settings
 from auto_neutron.constants import AHK_PATH
-from auto_neutron.settings.category_meta import delay_sync
+from auto_neutron.settings import delay_sync
 from auto_neutron.windows.gui.settings_window import SettingsWindowGUI
 
 log = logging.getLogger(__name__)

--- a/auto_neutron/windows/settings_window.py
+++ b/auto_neutron/windows/settings_window.py
@@ -54,12 +54,13 @@ class SettingsWindow(SettingsWindowGUI):
         self.ok_button.pressed.connect(self.settings_applied)
         self.ok_button.pressed.connect(self.save_settings)
         self.ok_button.pressed.connect(self.close)
+        self.retranslate()
 
     def get_ahk_path(self) -> None:
         """Ask the user for the AHK executable file path and save it to the setting."""
-        path, _ = QtWidgets.QFileDialog.get_open_file_name(
+        path, __ = QtWidgets.QFileDialog.get_open_file_name(
             self,
-            "Select AHK executable",
+            _("Select AHK executable"),
             str(AHK_PATH),
             filter="Executable files (*.exe)",
         )
@@ -70,9 +71,9 @@ class SettingsWindow(SettingsWindowGUI):
 
     def get_sound_path(self) -> None:
         """Ask the user for the alert file path and save it to the line edit."""
-        path, _ = QtWidgets.QFileDialog.get_open_file_name(
+        path, __ = QtWidgets.QFileDialog.get_open_file_name(
             self,
-            "Select alert file",
+            _("Select alert file"),
             "",
             filter="Audio files (*.wav *.mp3);;All types (*.*)",
         )

--- a/auto_neutron/windows/shut_down_window.py
+++ b/auto_neutron/windows/shut_down_window.py
@@ -36,6 +36,7 @@ class ShutDownWindow(ShutDownWindowGUI):
         self.quit_button.pressed.connect(QtWidgets.QApplication.instance().quit)
 
         self._change_journal(0)
+        self.retranslate()
 
     def _change_journal(self, index: int) -> None:
         """Change the selected journal, enable/disable the button depending on its shut down state."""

--- a/auto_neutron/windows/shut_down_window.py
+++ b/auto_neutron/windows/shut_down_window.py
@@ -1,6 +1,8 @@
 # This file is part of Auto_Neutron.
 # Copyright (C) 2019  Numerlor
 
+from __future__ import annotations
+
 from PySide6 import QtCore, QtWidgets
 
 # noinspection PyUnresolvedReferences

--- a/auto_neutron/windows/shut_down_window.py
+++ b/auto_neutron/windows/shut_down_window.py
@@ -36,9 +36,6 @@ class ShutDownWindow(ShutDownWindowGUI):
         self.quit_button.pressed.connect(QtWidgets.QApplication.instance().quit)
 
         self._change_journal(0)
-        rect = self.geometry
-        rect.adjust(-5, -18, 17, 5)  # expand the window a bit to give it breathing room
-        self.geometry = rect
 
     def _change_journal(self, index: int) -> None:
         """Change the selected journal, enable/disable the button depending on its shut down state."""

--- a/auto_neutron/windows/shut_down_window.py
+++ b/auto_neutron/windows/shut_down_window.py
@@ -48,3 +48,8 @@ class ShutDownWindow(ShutDownWindowGUI):
         *_, shut_down = journal.get_static_state()
         self.new_journal_button.enabled = not shut_down
         self._selected_journal = journal
+
+    def change_event(self, event: QtCore.QEvent) -> None:
+        """Retranslate the GUI when a language change occurs."""
+        if event.type() == QtCore.QEvent.LanguageChange:
+            self.retranslate()

--- a/auto_neutron/workers.py
+++ b/auto_neutron/workers.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import collections.abc
 import contextlib
 import json
 import logging
@@ -18,6 +17,8 @@ from __feature__ import snake_case, true_property  # noqa F401
 from auto_neutron.constants import STATUS_PATH
 
 if t.TYPE_CHECKING:
+    import collections.abc
+
     from auto_neutron.game_state import Location
     from auto_neutron.journal import Journal
     from auto_neutron.route_plots import RouteList

--- a/auto_neutron/workers.py
+++ b/auto_neutron/workers.py
@@ -40,10 +40,10 @@ class GameWorker(QtCore.QObject):
         self._timer.timeout.connect(partial(next, self._generator))
         self._stopped = False
         self.route = route
-        journal.system_sig.connect(self._emit_next_system)
+        journal.system_sig.connect(self.emit_next_system)
 
-    def _emit_next_system(self, location: Location) -> None:
-        """Emit the next system in the route and its index, or end of route."""
+    def emit_next_system(self, location: Location) -> None:
+        """Emit the next system in the route and its index if location is in the route, or the end of route signal."""
         with contextlib.suppress(ValueError):
             new_index = self.route.index(location.name) + 1
             if new_index < len(self.route):

--- a/auto_neutron/workers.py
+++ b/auto_neutron/workers.py
@@ -32,10 +32,10 @@ class GameWorker(QtCore.QObject):
     new_system_index_sig = QtCore.Signal(int)
     route_end_sig = QtCore.Signal()
 
-    def __init__(self, route: RouteList, journal: Journal):
-        super().__init__()
+    def __init__(self, parent: QtCore.QObject, route: RouteList, journal: Journal):
+        super().__init__(parent)
         self._generator = journal.tail()
-        self._timer = QtCore.QTimer()
+        self._timer = QtCore.QTimer(self)
         self._timer.interval = 250
         self._timer.timeout.connect(partial(next, self._generator))
         self._stopped = False
@@ -68,10 +68,10 @@ class StatusWorker(QtCore.QObject):
 
     status_signal = QtCore.Signal(dict)
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, parent: QtCore.QObject):
+        super().__init__(parent)
         self._generator = self.read_status()
-        self._timer = QtCore.QTimer()
+        self._timer = QtCore.QTimer(self)
         self._timer.timeout.connect(partial(next, self._generator))
         self._timer.interval = 250
 

--- a/auto_neutron/workers.py
+++ b/auto_neutron/workers.py
@@ -54,8 +54,6 @@ class GameWorker(QtCore.QObject):
     def start(self) -> None:
         """Start the worker to tail the journal file."""
         log.debug("Starting GameWorker.")
-        if self._stopped:
-            raise RuntimeError("Can't restart a stopped worker.")
         self._timer.start()
 
     def stop(self) -> None:
@@ -63,7 +61,6 @@ class GameWorker(QtCore.QObject):
         log.debug("Stopping GameWorker.")
         self._timer.stop()
         self._generator.close()
-        self._stopped = True
 
 
 class StatusWorker(QtCore.QObject):
@@ -77,14 +74,10 @@ class StatusWorker(QtCore.QObject):
         self._timer = QtCore.QTimer()
         self._timer.timeout.connect(partial(next, self._generator))
         self._timer.interval = 250
-        self._running = False
 
     def start(self) -> None:
         """Start the worker to follow the status file."""
         log.debug("Starting StatusWorker.")
-        if self._running:
-            raise RuntimeError("Worker already started")
-        self._running = True
         self._timer.start()
 
     def stop(self) -> None:
@@ -92,7 +85,6 @@ class StatusWorker(QtCore.QObject):
         log.debug("Stopping StatusWorker.")
         self._timer.stop()
         self._generator.close()
-        self._running = False
 
     def read_status(self) -> collections.abc.Generator[None, None, None]:
         """Emit status_signal with the status dict on every status file change."""

--- a/locale/README.md
+++ b/locale/README.md
@@ -1,0 +1,22 @@
+# Contributing translations
+
+Translations can be contributed as PRs containing the .po files to this repository.
+
+To create translations, you can use tools like [POEdit](https://poedit.net/), or manually translate in the files.
+
+Each directory under this directory represents a single language code, where the LC_MESSAGES sub dir contains the translations of the messages.
+
+So for example to create a de_DE translation you'd create a de_DE directory and put your translations in there.
+
+As the release distributions don't contain locale data for locales which are not contained in them, to see your translations you either have to run the application from source, or download the data online and paste it into the directory release of Auto_Neutron.
+
+To download the data online, go to https://pypi.org/project/Babel/#files, download tarball, extract it and merge the babel/locale-data directory from the main directory in the tarball with Auto_neutron's babel/locale-data irectory.
+
+After you do this, copy your compiled translations into Auto_Neutron's locale directory as specified above, and you should be able to choose the language in the settings.
+
+
+With a poetry environment initialized, Auto_Neutron defines a few utility task that are runnable with `poetry run task`\
+`i18n-init` initializes a directory containing a .po file to translate, takes the language code as the argument\
+`i18n-compile` compiles all the .po files in the locale directory\
+`i18n-update` updates the all the .po files after a new .pot file is extracted\
+`i18n-extract` extracts the .pot file from the project source

--- a/locale/auto_neutron.pot
+++ b/locale/auto_neutron.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Auto Neutron 2.0.3\n"
 "Report-Msgid-Bugs-To: Numerlor@gmail.com\n"
-"POT-Creation-Date: 2022-01-02 23:57+0100\n"
+"POT-Creation-Date: 2022-01-03 02:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,17 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: auto_neutron/windows/error_window.py:21
+#: auto_neutron/windows/error_window.py:52
+#: auto_neutron/windows/error_window.py:86
+msgid "Multiple unexpected errors have occurred (x{})"
+msgstr ""
+
+#: auto_neutron/windows/error_window.py:90
 msgid "Please make sure to report the bug at"
 msgstr ""
 
-#: auto_neutron/windows/error_window.py:24
+#: auto_neutron/windows/error_window.py:93
 msgid "and include the {file_name} file from"
-msgstr ""
-
-#: auto_neutron/windows/error_window.py:59
-#: auto_neutron/windows/error_window.py:88
-msgid "Multiple unexpected errors have occurred (x{})"
 msgstr ""
 
 #. NOTE: made jumps/ total
@@ -40,15 +40,15 @@ msgstr ""
 msgid "Jumps {}/{}"
 msgstr ""
 
-#: auto_neutron/windows/main_window.py:158
+#: auto_neutron/windows/main_window.py:163
 msgid "Scoopable"
 msgstr ""
 
-#: auto_neutron/windows/main_window.py:160
+#: auto_neutron/windows/main_window.py:165
 msgid "Neutron"
 msgstr ""
 
-#: auto_neutron/windows/main_window.py:163
+#: auto_neutron/windows/main_window.py:168
 msgid "Jumps"
 msgstr ""
 
@@ -85,24 +85,24 @@ msgid "Selected journal ended with a shut down event."
 msgstr ""
 
 #. NOTE: Source system
-#: auto_neutron/windows/new_route_window.py:447
+#: auto_neutron/windows/new_route_window.py:452
 msgid "Source: {}"
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:450
+#: auto_neutron/windows/new_route_window.py:455
 msgid "Saved location: {}"
 msgstr ""
 
 #. NOTE: destination system
-#: auto_neutron/windows/new_route_window.py:454
+#: auto_neutron/windows/new_route_window.py:459
 msgid "Destination: {}"
 msgstr ""
 
-#: auto_neutron/windows/settings_window.py:63
+#: auto_neutron/windows/settings_window.py:64
 msgid "Select AHK executable"
 msgstr ""
 
-#: auto_neutron/windows/settings_window.py:76
+#: auto_neutron/windows/settings_window.py:77
 msgid "Select alert file"
 msgstr ""
 
@@ -112,13 +112,13 @@ msgstr ""
 
 #: auto_neutron/windows/gui/error_window.py:48
 #: auto_neutron/windows/gui/missing_journal_window.py:40
-#: auto_neutron/windows/gui/shut_down_window.py:74
+#: auto_neutron/windows/gui/shut_down_window.py:76
 msgid "Quit"
 msgstr ""
 
 #: auto_neutron/windows/gui/error_window.py:49
 #: auto_neutron/windows/gui/main_window.py:128
-#: auto_neutron/windows/gui/shut_down_window.py:73
+#: auto_neutron/windows/gui/shut_down_window.py:75
 msgid "Save route"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgid "Start a new route"
 msgstr ""
 
 #: auto_neutron/windows/gui/main_window.py:131
-#: auto_neutron/windows/gui/settings_window.py:205
+#: auto_neutron/windows/gui/settings_window.py:219
 msgid "Settings"
 msgstr ""
 
@@ -246,136 +246,140 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:101
-#: auto_neutron/windows/gui/shut_down_window.py:70
+#: auto_neutron/windows/gui/new_route_window.py:102
+#: auto_neutron/windows/gui/shut_down_window.py:71
 msgid "Last journal"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:101
-#: auto_neutron/windows/gui/shut_down_window.py:70
+#: auto_neutron/windows/gui/new_route_window.py:102
+#: auto_neutron/windows/gui/shut_down_window.py:71
 msgid "Second to last"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:101
-#: auto_neutron/windows/gui/shut_down_window.py:70
+#: auto_neutron/windows/gui/new_route_window.py:102
+#: auto_neutron/windows/gui/shut_down_window.py:71
 msgid "Third to last"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:152
+#: auto_neutron/windows/gui/new_route_window.py:154
 msgid "Range"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:153
+#: auto_neutron/windows/gui/new_route_window.py:155
 msgid "Efficiency"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:154
-#: auto_neutron/windows/gui/new_route_window.py:204
+#: auto_neutron/windows/gui/new_route_window.py:156
+#: auto_neutron/windows/gui/new_route_window.py:206
 msgid "Nearest"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:199
+#: auto_neutron/windows/gui/new_route_window.py:201
 msgid "Already supercharged"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:200
+#: auto_neutron/windows/gui/new_route_window.py:202
 msgid "Use supercharge"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:201
+#: auto_neutron/windows/gui/new_route_window.py:203
 msgid "Use FSD injections"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:202
+#: auto_neutron/windows/gui/new_route_window.py:204
 msgid "Exclude secondary stars"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:203
+#: auto_neutron/windows/gui/new_route_window.py:205
 msgid "Use ship from clipboard"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:299
+#: auto_neutron/windows/gui/new_route_window.py:301
 msgid "CSV"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:300
+#: auto_neutron/windows/gui/new_route_window.py:302
 msgid "Neutron plotter"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:301
+#: auto_neutron/windows/gui/new_route_window.py:303
 msgid "Galaxy plotter"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:302
+#: auto_neutron/windows/gui/new_route_window.py:304
 msgid "Saved route"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:179
+#: auto_neutron/windows/gui/settings_window.py:190
 msgid "Ok"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:180
+#: auto_neutron/windows/gui/settings_window.py:191
 msgid "Apply"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:183
+#: auto_neutron/windows/gui/settings_window.py:195
 msgid "Appearance"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:183
+#: auto_neutron/windows/gui/settings_window.py:195
 msgid "Behaviour"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:183
+#: auto_neutron/windows/gui/settings_window.py:195
 msgid "Alerts"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:183
+#: auto_neutron/windows/gui/settings_window.py:195
 msgid "AHK script"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:189
+#: auto_neutron/windows/gui/settings_window.py:202
 msgid "Bold"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:190
+#: auto_neutron/windows/gui/settings_window.py:203
+msgid "Language"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:204
 msgid "Dark mode"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:192
+#: auto_neutron/windows/gui/settings_window.py:206
 msgid "Save route on window close"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:193
+#: auto_neutron/windows/gui/settings_window.py:207
 msgid "Copy Mode"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:194
+#: auto_neutron/windows/gui/settings_window.py:208
 msgid "AHK Path"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:195
+#: auto_neutron/windows/gui/settings_window.py:209
 msgid "Auto scroll"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:197
+#: auto_neutron/windows/gui/settings_window.py:211
 msgid "Taskbar fuel alert"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:198
+#: auto_neutron/windows/gui/settings_window.py:212
 msgid "Sound fuel alert"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:199
+#: auto_neutron/windows/gui/settings_window.py:213
 msgid "Custom sound alert file:"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:201
+#: auto_neutron/windows/gui/settings_window.py:215
 #, python-format
 msgid "%% of maximum fuel usage left in tank before triggering alert"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:206
+#: auto_neutron/windows/gui/settings_window.py:220
 msgid ""
 "Bind to trigger the script, # for win key, ! for alt, ^ for control, + "
 "for shift"
@@ -385,6 +389,6 @@ msgstr ""
 msgid "Game shut down"
 msgstr ""
 
-#: auto_neutron/windows/gui/shut_down_window.py:72
+#: auto_neutron/windows/gui/shut_down_window.py:74
 msgid "New journal"
 msgstr ""

--- a/locale/auto_neutron.pot
+++ b/locale/auto_neutron.pot
@@ -1,0 +1,390 @@
+# Translations template for Auto_Neutron.
+# Copyright (C) 2019 Numerlor
+# This file is distributed under the same license as the Auto_Neutron project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Auto Neutron 2.0.3\n"
+"Report-Msgid-Bugs-To: Numerlor@gmail.com\n"
+"POT-Creation-Date: 2022-01-02 23:57+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: auto_neutron/windows/error_window.py:21
+msgid "Please make sure to report the bug at"
+msgstr ""
+
+#: auto_neutron/windows/error_window.py:24
+msgid "and include the {file_name} file from"
+msgstr ""
+
+#: auto_neutron/windows/error_window.py:59
+#: auto_neutron/windows/error_window.py:88
+msgid "Multiple unexpected errors have occurred (x{})"
+msgstr ""
+
+#. NOTE: made jumps/ total
+#: auto_neutron/windows/main_window.py:111
+msgid "System name ({}/{})"
+msgstr ""
+
+#. NOTE: made jumps/ total
+#: auto_neutron/windows/main_window.py:124
+msgid "Jumps {}/{}"
+msgstr ""
+
+#: auto_neutron/windows/main_window.py:158
+msgid "Scoopable"
+msgstr ""
+
+#: auto_neutron/windows/main_window.py:160
+msgid "Neutron"
+msgstr ""
+
+#: auto_neutron/windows/main_window.py:163
+msgid "Jumps"
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:298
+msgid "Select CSV file"
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:327
+msgid "Invalid CSV file."
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:332
+msgid "CSV file doesn't exist."
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:334
+msgid "Invalid CSV file: "
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:336
+msgid "Truncated data in CSV file."
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:338
+msgid "Invalid data in CSV file."
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:340
+msgid "Invalid path."
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:400
+msgid "Selected journal ended with a shut down event."
+msgstr ""
+
+#. NOTE: Source system
+#: auto_neutron/windows/new_route_window.py:447
+msgid "Source: {}"
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:450
+msgid "Saved location: {}"
+msgstr ""
+
+#. NOTE: destination system
+#: auto_neutron/windows/new_route_window.py:454
+msgid "Destination: {}"
+msgstr ""
+
+#: auto_neutron/windows/settings_window.py:63
+msgid "Select AHK executable"
+msgstr ""
+
+#: auto_neutron/windows/settings_window.py:76
+msgid "Select alert file"
+msgstr ""
+
+#: auto_neutron/windows/gui/error_window.py:47
+msgid "An unexpected error has occurred"
+msgstr ""
+
+#: auto_neutron/windows/gui/error_window.py:48
+#: auto_neutron/windows/gui/missing_journal_window.py:40
+#: auto_neutron/windows/gui/shut_down_window.py:74
+msgid "Quit"
+msgstr ""
+
+#: auto_neutron/windows/gui/error_window.py:49
+#: auto_neutron/windows/gui/main_window.py:128
+#: auto_neutron/windows/gui/shut_down_window.py:73
+msgid "Save route"
+msgstr ""
+
+#: auto_neutron/windows/gui/license_window.py:40
+msgid "PySide6 Copyright (C) 2015 The Qt Company Ltd."
+msgstr ""
+
+#: auto_neutron/windows/gui/license_window.py:41
+msgid "Auto_Neutron Copyright (C) 2019 Numerlor"
+msgstr ""
+
+#: auto_neutron/windows/gui/license_window.py:42
+msgid "Auto_Neutron comes with ABSOLUTELY NO WARRANTY)."
+msgstr ""
+
+#: auto_neutron/windows/gui/license_window.py:43
+msgid ""
+"This is free software, and you are welcome to redistribute it under "
+"certain conditions; "
+msgstr ""
+
+#: auto_neutron/windows/gui/main_window.py:127
+msgid "Edit"
+msgstr ""
+
+#: auto_neutron/windows/gui/main_window.py:129
+msgid "Copy"
+msgstr ""
+
+#: auto_neutron/windows/gui/main_window.py:130
+msgid "Start a new route"
+msgstr ""
+
+#: auto_neutron/windows/gui/main_window.py:131
+#: auto_neutron/windows/gui/settings_window.py:205
+msgid "Settings"
+msgstr ""
+
+#: auto_neutron/windows/gui/main_window.py:132
+msgid "About"
+msgstr ""
+
+#: auto_neutron/windows/gui/main_window.py:137
+#: auto_neutron/windows/gui/nearest_window.py:131
+msgid "System name"
+msgstr ""
+
+#: auto_neutron/windows/gui/main_window.py:139
+#: auto_neutron/windows/gui/nearest_window.py:132
+msgid "Distance"
+msgstr ""
+
+#: auto_neutron/windows/gui/main_window.py:141
+msgid "Remaining"
+msgstr ""
+
+#: auto_neutron/windows/gui/missing_journal_window.py:39
+msgid "Journal folder not found or missing files."
+msgstr ""
+
+#. NOTE: Coordinate
+#: auto_neutron/windows/gui/nearest_window.py:134
+msgid "X"
+msgstr ""
+
+#. NOTE: Coordinate
+#: auto_neutron/windows/gui/nearest_window.py:136
+msgid "Y"
+msgstr ""
+
+#. NOTE: Coordinate
+#: auto_neutron/windows/gui/nearest_window.py:138
+msgid "Z"
+msgstr ""
+
+#: auto_neutron/windows/gui/nearest_window.py:140
+msgid "From location"
+msgstr ""
+
+#: auto_neutron/windows/gui/nearest_window.py:141
+msgid "Copy coordinates from the current location"
+msgstr ""
+
+#: auto_neutron/windows/gui/nearest_window.py:144
+msgid "From target"
+msgstr ""
+
+#: auto_neutron/windows/gui/nearest_window.py:145
+msgid "Copy approximate coordinates from the current target"
+msgstr ""
+
+#: auto_neutron/windows/gui/nearest_window.py:148
+msgid "To source"
+msgstr ""
+
+#: auto_neutron/windows/gui/nearest_window.py:149
+msgid "Copy searched system name to the source input"
+msgstr ""
+
+#: auto_neutron/windows/gui/nearest_window.py:152
+msgid "To destination"
+msgstr ""
+
+#: auto_neutron/windows/gui/nearest_window.py:153
+msgid "Copy searched system name to the destination input"
+msgstr ""
+
+#: auto_neutron/windows/gui/nearest_window.py:157
+msgid "Search"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:93
+msgid "Source system"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:94
+msgid "Destination system"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:96
+msgid "Cargo"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:98
+msgid "Submit"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:101
+#: auto_neutron/windows/gui/shut_down_window.py:70
+msgid "Last journal"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:101
+#: auto_neutron/windows/gui/shut_down_window.py:70
+msgid "Second to last"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:101
+#: auto_neutron/windows/gui/shut_down_window.py:70
+msgid "Third to last"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:152
+msgid "Range"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:153
+msgid "Efficiency"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:154
+#: auto_neutron/windows/gui/new_route_window.py:204
+msgid "Nearest"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:199
+msgid "Already supercharged"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:200
+msgid "Use supercharge"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:201
+msgid "Use FSD injections"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:202
+msgid "Exclude secondary stars"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:203
+msgid "Use ship from clipboard"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:299
+msgid "CSV"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:300
+msgid "Neutron plotter"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:301
+msgid "Galaxy plotter"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:302
+msgid "Saved route"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:179
+msgid "Ok"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:180
+msgid "Apply"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:183
+msgid "Appearance"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:183
+msgid "Behaviour"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:183
+msgid "Alerts"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:183
+msgid "AHK script"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:189
+msgid "Bold"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:190
+msgid "Dark mode"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:192
+msgid "Save route on window close"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:193
+msgid "Copy Mode"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:194
+msgid "AHK Path"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:195
+msgid "Auto scroll"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:197
+msgid "Taskbar fuel alert"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:198
+msgid "Sound fuel alert"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:199
+msgid "Custom sound alert file:"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:201
+#, python-format
+msgid "%% of maximum fuel usage left in tank before triggering alert"
+msgstr ""
+
+#: auto_neutron/windows/gui/settings_window.py:206
+msgid ""
+"Bind to trigger the script, # for win key, ! for alt, ^ for control, + "
+"for shift"
+msgstr ""
+
+#: auto_neutron/windows/gui/shut_down_window.py:67
+msgid "Game shut down"
+msgstr ""
+
+#: auto_neutron/windows/gui/shut_down_window.py:72
+msgid "New journal"
+msgstr ""

--- a/locale/en/LC_MESSAGES/auto_neutron.po
+++ b/locale/en/LC_MESSAGES/auto_neutron.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Auto Neutron 2.0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/Numerlor/Auto_Neutron/issues\n"
-"POT-Creation-Date: 2022-01-02 23:57+0100\n"
+"POT-Creation-Date: 2022-01-03 02:17+0100\n"
 "PO-Revision-Date: 2022-01-02 23:58+0100\n"
 "Last-Translator: Numerlor <Numerlor@gmail.com>\n"
 "Language: en\n"
@@ -18,18 +18,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: auto_neutron/windows/error_window.py:21
+#: auto_neutron/windows/error_window.py:52
+#: auto_neutron/windows/error_window.py:86
+msgid "Multiple unexpected errors have occurred (x{})"
+msgstr "Multiple unexpected errors have occurred (x{})"
+
+#: auto_neutron/windows/error_window.py:90
 msgid "Please make sure to report the bug at"
 msgstr "Please make sure to report the bug at"
 
-#: auto_neutron/windows/error_window.py:24
+#: auto_neutron/windows/error_window.py:93
 msgid "and include the {file_name} file from"
 msgstr "and include the {file_name} file from"
-
-#: auto_neutron/windows/error_window.py:59
-#: auto_neutron/windows/error_window.py:88
-msgid "Multiple unexpected errors have occurred (x{})"
-msgstr "Multiple unexpected errors have occurred (x{})"
 
 #. NOTE: made jumps/ total
 #: auto_neutron/windows/main_window.py:111
@@ -41,15 +41,15 @@ msgstr "System name ({}/{})"
 msgid "Jumps {}/{}"
 msgstr "Jumps {}/{}"
 
-#: auto_neutron/windows/main_window.py:158
+#: auto_neutron/windows/main_window.py:163
 msgid "Scoopable"
 msgstr "Scoopable"
 
-#: auto_neutron/windows/main_window.py:160
+#: auto_neutron/windows/main_window.py:165
 msgid "Neutron"
 msgstr "Neutron"
 
-#: auto_neutron/windows/main_window.py:163
+#: auto_neutron/windows/main_window.py:168
 msgid "Jumps"
 msgstr "Jumps"
 
@@ -86,24 +86,24 @@ msgid "Selected journal ended with a shut down event."
 msgstr "Selected journal ended with a shut down event."
 
 #. NOTE: Source system
-#: auto_neutron/windows/new_route_window.py:447
+#: auto_neutron/windows/new_route_window.py:452
 msgid "Source: {}"
 msgstr "Source: {}"
 
-#: auto_neutron/windows/new_route_window.py:450
+#: auto_neutron/windows/new_route_window.py:455
 msgid "Saved location: {}"
 msgstr "Saved location: {}"
 
 #. NOTE: destination system
-#: auto_neutron/windows/new_route_window.py:454
+#: auto_neutron/windows/new_route_window.py:459
 msgid "Destination: {}"
 msgstr "Destination: {}"
 
-#: auto_neutron/windows/settings_window.py:63
+#: auto_neutron/windows/settings_window.py:64
 msgid "Select AHK executable"
 msgstr "Select AHK executable"
 
-#: auto_neutron/windows/settings_window.py:76
+#: auto_neutron/windows/settings_window.py:77
 msgid "Select alert file"
 msgstr "Select alert file"
 
@@ -113,13 +113,13 @@ msgstr "An unexpected error has occurred"
 
 #: auto_neutron/windows/gui/error_window.py:48
 #: auto_neutron/windows/gui/missing_journal_window.py:40
-#: auto_neutron/windows/gui/shut_down_window.py:74
+#: auto_neutron/windows/gui/shut_down_window.py:76
 msgid "Quit"
 msgstr "Quit"
 
 #: auto_neutron/windows/gui/error_window.py:49
 #: auto_neutron/windows/gui/main_window.py:128
-#: auto_neutron/windows/gui/shut_down_window.py:73
+#: auto_neutron/windows/gui/shut_down_window.py:75
 msgid "Save route"
 msgstr "Save route"
 
@@ -156,7 +156,7 @@ msgid "Start a new route"
 msgstr "Start a new route"
 
 #: auto_neutron/windows/gui/main_window.py:131
-#: auto_neutron/windows/gui/settings_window.py:205
+#: auto_neutron/windows/gui/settings_window.py:219
 msgid "Settings"
 msgstr "Settings"
 
@@ -249,136 +249,141 @@ msgstr "Cargo"
 msgid "Submit"
 msgstr "Submit"
 
-#: auto_neutron/windows/gui/new_route_window.py:101
-#: auto_neutron/windows/gui/shut_down_window.py:70
+#: auto_neutron/windows/gui/new_route_window.py:102
+#: auto_neutron/windows/gui/shut_down_window.py:71
 msgid "Last journal"
 msgstr "Last journal"
 
-#: auto_neutron/windows/gui/new_route_window.py:101
-#: auto_neutron/windows/gui/shut_down_window.py:70
+#: auto_neutron/windows/gui/new_route_window.py:102
+#: auto_neutron/windows/gui/shut_down_window.py:71
 msgid "Second to last"
 msgstr "Second to last"
 
-#: auto_neutron/windows/gui/new_route_window.py:101
-#: auto_neutron/windows/gui/shut_down_window.py:70
+#: auto_neutron/windows/gui/new_route_window.py:102
+#: auto_neutron/windows/gui/shut_down_window.py:71
 msgid "Third to last"
 msgstr "Third to last"
 
-#: auto_neutron/windows/gui/new_route_window.py:152
+#: auto_neutron/windows/gui/new_route_window.py:154
 msgid "Range"
 msgstr "Range"
 
-#: auto_neutron/windows/gui/new_route_window.py:153
+#: auto_neutron/windows/gui/new_route_window.py:155
 msgid "Efficiency"
 msgstr "Efficiency"
 
-#: auto_neutron/windows/gui/new_route_window.py:154
-#: auto_neutron/windows/gui/new_route_window.py:204
+#: auto_neutron/windows/gui/new_route_window.py:156
+#: auto_neutron/windows/gui/new_route_window.py:206
 msgid "Nearest"
 msgstr "Nearest"
 
-#: auto_neutron/windows/gui/new_route_window.py:199
+#: auto_neutron/windows/gui/new_route_window.py:201
 msgid "Already supercharged"
 msgstr "Already supercharged"
 
-#: auto_neutron/windows/gui/new_route_window.py:200
+#: auto_neutron/windows/gui/new_route_window.py:202
 msgid "Use supercharge"
 msgstr "Use supercharge"
 
-#: auto_neutron/windows/gui/new_route_window.py:201
+#: auto_neutron/windows/gui/new_route_window.py:203
 msgid "Use FSD injections"
 msgstr "Use FSD injections"
 
-#: auto_neutron/windows/gui/new_route_window.py:202
+#: auto_neutron/windows/gui/new_route_window.py:204
 msgid "Exclude secondary stars"
 msgstr "Exclude secondary stars"
 
-#: auto_neutron/windows/gui/new_route_window.py:203
+#: auto_neutron/windows/gui/new_route_window.py:205
 msgid "Use ship from clipboard"
 msgstr "Use ship from clipboard"
 
-#: auto_neutron/windows/gui/new_route_window.py:299
+#: auto_neutron/windows/gui/new_route_window.py:301
 msgid "CSV"
 msgstr "CSV"
 
-#: auto_neutron/windows/gui/new_route_window.py:300
+#: auto_neutron/windows/gui/new_route_window.py:302
 msgid "Neutron plotter"
 msgstr "Neutron plotter"
 
-#: auto_neutron/windows/gui/new_route_window.py:301
+#: auto_neutron/windows/gui/new_route_window.py:303
 msgid "Galaxy plotter"
 msgstr "Galaxy plotter"
 
-#: auto_neutron/windows/gui/new_route_window.py:302
+#: auto_neutron/windows/gui/new_route_window.py:304
 msgid "Saved route"
 msgstr "Saved route"
 
-#: auto_neutron/windows/gui/settings_window.py:179
+#: auto_neutron/windows/gui/settings_window.py:190
 msgid "Ok"
 msgstr "Ok"
 
-#: auto_neutron/windows/gui/settings_window.py:180
+#: auto_neutron/windows/gui/settings_window.py:191
 msgid "Apply"
 msgstr "Apply"
 
-#: auto_neutron/windows/gui/settings_window.py:183
+#: auto_neutron/windows/gui/settings_window.py:195
 msgid "Appearance"
 msgstr "Appearance"
 
-#: auto_neutron/windows/gui/settings_window.py:183
+#: auto_neutron/windows/gui/settings_window.py:195
 msgid "Behaviour"
 msgstr "Behaviour"
 
-#: auto_neutron/windows/gui/settings_window.py:183
+#: auto_neutron/windows/gui/settings_window.py:195
 msgid "Alerts"
 msgstr "Alerts"
 
-#: auto_neutron/windows/gui/settings_window.py:183
+#: auto_neutron/windows/gui/settings_window.py:195
 msgid "AHK script"
 msgstr "AHK script"
 
-#: auto_neutron/windows/gui/settings_window.py:189
+#: auto_neutron/windows/gui/settings_window.py:202
 msgid "Bold"
 msgstr "Bold"
 
-#: auto_neutron/windows/gui/settings_window.py:190
+#: auto_neutron/windows/gui/settings_window.py:203
+#, fuzzy
+msgid "Language"
+msgstr "Language"
+
+#: auto_neutron/windows/gui/settings_window.py:204
 msgid "Dark mode"
 msgstr "Dark mode"
 
-#: auto_neutron/windows/gui/settings_window.py:192
+#: auto_neutron/windows/gui/settings_window.py:206
 msgid "Save route on window close"
 msgstr "Save route on window close"
 
-#: auto_neutron/windows/gui/settings_window.py:193
+#: auto_neutron/windows/gui/settings_window.py:207
 msgid "Copy Mode"
 msgstr "Copy Mode"
 
-#: auto_neutron/windows/gui/settings_window.py:194
+#: auto_neutron/windows/gui/settings_window.py:208
 msgid "AHK Path"
 msgstr "AHK Path"
 
-#: auto_neutron/windows/gui/settings_window.py:195
+#: auto_neutron/windows/gui/settings_window.py:209
 msgid "Auto scroll"
 msgstr "Auto scroll"
 
-#: auto_neutron/windows/gui/settings_window.py:197
+#: auto_neutron/windows/gui/settings_window.py:211
 msgid "Taskbar fuel alert"
 msgstr "Taskbar fuel alert"
 
-#: auto_neutron/windows/gui/settings_window.py:198
+#: auto_neutron/windows/gui/settings_window.py:212
 msgid "Sound fuel alert"
 msgstr "Sound fuel alert"
 
-#: auto_neutron/windows/gui/settings_window.py:199
+#: auto_neutron/windows/gui/settings_window.py:213
 msgid "Custom sound alert file:"
 msgstr "Custom sound alert file:"
 
-#: auto_neutron/windows/gui/settings_window.py:201
+#: auto_neutron/windows/gui/settings_window.py:215
 #, python-format
 msgid "%% of maximum fuel usage left in tank before triggering alert"
 msgstr "%% of maximum fuel usage left in tank before triggering alert"
 
-#: auto_neutron/windows/gui/settings_window.py:206
+#: auto_neutron/windows/gui/settings_window.py:220
 msgid ""
 "Bind to trigger the script, # for win key, ! for alt, ^ for control, + "
 "for shift"
@@ -390,6 +395,6 @@ msgstr ""
 msgid "Game shut down"
 msgstr "Game shut down"
 
-#: auto_neutron/windows/gui/shut_down_window.py:72
+#: auto_neutron/windows/gui/shut_down_window.py:74
 msgid "New journal"
 msgstr "New journal"

--- a/locale/en/LC_MESSAGES/auto_neutron.po
+++ b/locale/en/LC_MESSAGES/auto_neutron.po
@@ -1,0 +1,395 @@
+# English translations for Auto_Neutron.
+# Copyright (C) 2019 Numerlor
+# This file is distributed under the same license as the Auto_Neutron project.
+# FIRST AUTHOR Numerlor, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Auto Neutron 2.0.3\n"
+"Report-Msgid-Bugs-To: https://github.com/Numerlor/Auto_Neutron/issues\n"
+"POT-Creation-Date: 2022-01-02 23:57+0100\n"
+"PO-Revision-Date: 2022-01-02 23:58+0100\n"
+"Last-Translator: Numerlor <Numerlor@gmail.com>\n"
+"Language: en\n"
+"Language-Team: en <Numerlor@gmail.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: auto_neutron/windows/error_window.py:21
+msgid "Please make sure to report the bug at"
+msgstr "Please make sure to report the bug at"
+
+#: auto_neutron/windows/error_window.py:24
+msgid "and include the {file_name} file from"
+msgstr "and include the {file_name} file from"
+
+#: auto_neutron/windows/error_window.py:59
+#: auto_neutron/windows/error_window.py:88
+msgid "Multiple unexpected errors have occurred (x{})"
+msgstr "Multiple unexpected errors have occurred (x{})"
+
+#. NOTE: made jumps/ total
+#: auto_neutron/windows/main_window.py:111
+msgid "System name ({}/{})"
+msgstr "System name ({}/{})"
+
+#. NOTE: made jumps/ total
+#: auto_neutron/windows/main_window.py:124
+msgid "Jumps {}/{}"
+msgstr "Jumps {}/{}"
+
+#: auto_neutron/windows/main_window.py:158
+msgid "Scoopable"
+msgstr "Scoopable"
+
+#: auto_neutron/windows/main_window.py:160
+msgid "Neutron"
+msgstr "Neutron"
+
+#: auto_neutron/windows/main_window.py:163
+msgid "Jumps"
+msgstr "Jumps"
+
+#: auto_neutron/windows/new_route_window.py:298
+msgid "Select CSV file"
+msgstr "Select CSV file"
+
+#: auto_neutron/windows/new_route_window.py:327
+msgid "Invalid CSV file."
+msgstr "Invalid CSV file."
+
+#: auto_neutron/windows/new_route_window.py:332
+msgid "CSV file doesn't exist."
+msgstr "CSV file doesn't exist."
+
+#: auto_neutron/windows/new_route_window.py:334
+msgid "Invalid CSV file: "
+msgstr "Invalid CSV file: "
+
+#: auto_neutron/windows/new_route_window.py:336
+msgid "Truncated data in CSV file."
+msgstr "Truncated data in CSV file."
+
+#: auto_neutron/windows/new_route_window.py:338
+msgid "Invalid data in CSV file."
+msgstr "Invalid data in CSV file."
+
+#: auto_neutron/windows/new_route_window.py:340
+msgid "Invalid path."
+msgstr "Invalid path."
+
+#: auto_neutron/windows/new_route_window.py:400
+msgid "Selected journal ended with a shut down event."
+msgstr "Selected journal ended with a shut down event."
+
+#. NOTE: Source system
+#: auto_neutron/windows/new_route_window.py:447
+msgid "Source: {}"
+msgstr "Source: {}"
+
+#: auto_neutron/windows/new_route_window.py:450
+msgid "Saved location: {}"
+msgstr "Saved location: {}"
+
+#. NOTE: destination system
+#: auto_neutron/windows/new_route_window.py:454
+msgid "Destination: {}"
+msgstr "Destination: {}"
+
+#: auto_neutron/windows/settings_window.py:63
+msgid "Select AHK executable"
+msgstr "Select AHK executable"
+
+#: auto_neutron/windows/settings_window.py:76
+msgid "Select alert file"
+msgstr "Select alert file"
+
+#: auto_neutron/windows/gui/error_window.py:47
+msgid "An unexpected error has occurred"
+msgstr "An unexpected error has occurred"
+
+#: auto_neutron/windows/gui/error_window.py:48
+#: auto_neutron/windows/gui/missing_journal_window.py:40
+#: auto_neutron/windows/gui/shut_down_window.py:74
+msgid "Quit"
+msgstr "Quit"
+
+#: auto_neutron/windows/gui/error_window.py:49
+#: auto_neutron/windows/gui/main_window.py:128
+#: auto_neutron/windows/gui/shut_down_window.py:73
+msgid "Save route"
+msgstr "Save route"
+
+#: auto_neutron/windows/gui/license_window.py:40
+msgid "PySide6 Copyright (C) 2015 The Qt Company Ltd."
+msgstr "PySide6 Copyright (C) 2015 The Qt Company Ltd."
+
+#: auto_neutron/windows/gui/license_window.py:41
+msgid "Auto_Neutron Copyright (C) 2019 Numerlor"
+msgstr "Auto_Neutron Copyright (C) 2019 Numerlor"
+
+#: auto_neutron/windows/gui/license_window.py:42
+msgid "Auto_Neutron comes with ABSOLUTELY NO WARRANTY)."
+msgstr "Auto_Neutron comes with ABSOLUTELY NO WARRANTY)."
+
+#: auto_neutron/windows/gui/license_window.py:43
+msgid ""
+"This is free software, and you are welcome to redistribute it under "
+"certain conditions; "
+msgstr ""
+"This is free software, and you are welcome to redistribute it under "
+"certain conditions; "
+
+#: auto_neutron/windows/gui/main_window.py:127
+msgid "Edit"
+msgstr "Edit"
+
+#: auto_neutron/windows/gui/main_window.py:129
+msgid "Copy"
+msgstr "Copy"
+
+#: auto_neutron/windows/gui/main_window.py:130
+msgid "Start a new route"
+msgstr "Start a new route"
+
+#: auto_neutron/windows/gui/main_window.py:131
+#: auto_neutron/windows/gui/settings_window.py:205
+msgid "Settings"
+msgstr "Settings"
+
+#: auto_neutron/windows/gui/main_window.py:132
+msgid "About"
+msgstr "About"
+
+#: auto_neutron/windows/gui/main_window.py:137
+#: auto_neutron/windows/gui/nearest_window.py:131
+msgid "System name"
+msgstr "System name"
+
+#: auto_neutron/windows/gui/main_window.py:139
+#: auto_neutron/windows/gui/nearest_window.py:132
+msgid "Distance"
+msgstr "Distance"
+
+#: auto_neutron/windows/gui/main_window.py:141
+msgid "Remaining"
+msgstr "Remaining"
+
+#: auto_neutron/windows/gui/missing_journal_window.py:39
+msgid "Journal folder not found or missing files."
+msgstr "Journal folder not found or missing files."
+
+#. NOTE: Coordinate
+#: auto_neutron/windows/gui/nearest_window.py:134
+msgid "X"
+msgstr "X"
+
+#. NOTE: Coordinate
+#: auto_neutron/windows/gui/nearest_window.py:136
+msgid "Y"
+msgstr "Y"
+
+#. NOTE: Coordinate
+#: auto_neutron/windows/gui/nearest_window.py:138
+msgid "Z"
+msgstr "Z"
+
+#: auto_neutron/windows/gui/nearest_window.py:140
+msgid "From location"
+msgstr "From location"
+
+#: auto_neutron/windows/gui/nearest_window.py:141
+msgid "Copy coordinates from the current location"
+msgstr "Copy coordinates from the current location"
+
+#: auto_neutron/windows/gui/nearest_window.py:144
+msgid "From target"
+msgstr "From target"
+
+#: auto_neutron/windows/gui/nearest_window.py:145
+msgid "Copy approximate coordinates from the current target"
+msgstr "Copy approximate coordinates from the current target"
+
+#: auto_neutron/windows/gui/nearest_window.py:148
+msgid "To source"
+msgstr "To source"
+
+#: auto_neutron/windows/gui/nearest_window.py:149
+msgid "Copy searched system name to the source input"
+msgstr "Copy searched system name to the source input"
+
+#: auto_neutron/windows/gui/nearest_window.py:152
+msgid "To destination"
+msgstr "To destination"
+
+#: auto_neutron/windows/gui/nearest_window.py:153
+msgid "Copy searched system name to the destination input"
+msgstr "Copy searched system name to the destination input"
+
+#: auto_neutron/windows/gui/nearest_window.py:157
+msgid "Search"
+msgstr "Search"
+
+#: auto_neutron/windows/gui/new_route_window.py:93
+msgid "Source system"
+msgstr "Source system"
+
+#: auto_neutron/windows/gui/new_route_window.py:94
+msgid "Destination system"
+msgstr "Destination system"
+
+#: auto_neutron/windows/gui/new_route_window.py:96
+msgid "Cargo"
+msgstr "Cargo"
+
+#: auto_neutron/windows/gui/new_route_window.py:98
+msgid "Submit"
+msgstr "Submit"
+
+#: auto_neutron/windows/gui/new_route_window.py:101
+#: auto_neutron/windows/gui/shut_down_window.py:70
+msgid "Last journal"
+msgstr "Last journal"
+
+#: auto_neutron/windows/gui/new_route_window.py:101
+#: auto_neutron/windows/gui/shut_down_window.py:70
+msgid "Second to last"
+msgstr "Second to last"
+
+#: auto_neutron/windows/gui/new_route_window.py:101
+#: auto_neutron/windows/gui/shut_down_window.py:70
+msgid "Third to last"
+msgstr "Third to last"
+
+#: auto_neutron/windows/gui/new_route_window.py:152
+msgid "Range"
+msgstr "Range"
+
+#: auto_neutron/windows/gui/new_route_window.py:153
+msgid "Efficiency"
+msgstr "Efficiency"
+
+#: auto_neutron/windows/gui/new_route_window.py:154
+#: auto_neutron/windows/gui/new_route_window.py:204
+msgid "Nearest"
+msgstr "Nearest"
+
+#: auto_neutron/windows/gui/new_route_window.py:199
+msgid "Already supercharged"
+msgstr "Already supercharged"
+
+#: auto_neutron/windows/gui/new_route_window.py:200
+msgid "Use supercharge"
+msgstr "Use supercharge"
+
+#: auto_neutron/windows/gui/new_route_window.py:201
+msgid "Use FSD injections"
+msgstr "Use FSD injections"
+
+#: auto_neutron/windows/gui/new_route_window.py:202
+msgid "Exclude secondary stars"
+msgstr "Exclude secondary stars"
+
+#: auto_neutron/windows/gui/new_route_window.py:203
+msgid "Use ship from clipboard"
+msgstr "Use ship from clipboard"
+
+#: auto_neutron/windows/gui/new_route_window.py:299
+msgid "CSV"
+msgstr "CSV"
+
+#: auto_neutron/windows/gui/new_route_window.py:300
+msgid "Neutron plotter"
+msgstr "Neutron plotter"
+
+#: auto_neutron/windows/gui/new_route_window.py:301
+msgid "Galaxy plotter"
+msgstr "Galaxy plotter"
+
+#: auto_neutron/windows/gui/new_route_window.py:302
+msgid "Saved route"
+msgstr "Saved route"
+
+#: auto_neutron/windows/gui/settings_window.py:179
+msgid "Ok"
+msgstr "Ok"
+
+#: auto_neutron/windows/gui/settings_window.py:180
+msgid "Apply"
+msgstr "Apply"
+
+#: auto_neutron/windows/gui/settings_window.py:183
+msgid "Appearance"
+msgstr "Appearance"
+
+#: auto_neutron/windows/gui/settings_window.py:183
+msgid "Behaviour"
+msgstr "Behaviour"
+
+#: auto_neutron/windows/gui/settings_window.py:183
+msgid "Alerts"
+msgstr "Alerts"
+
+#: auto_neutron/windows/gui/settings_window.py:183
+msgid "AHK script"
+msgstr "AHK script"
+
+#: auto_neutron/windows/gui/settings_window.py:189
+msgid "Bold"
+msgstr "Bold"
+
+#: auto_neutron/windows/gui/settings_window.py:190
+msgid "Dark mode"
+msgstr "Dark mode"
+
+#: auto_neutron/windows/gui/settings_window.py:192
+msgid "Save route on window close"
+msgstr "Save route on window close"
+
+#: auto_neutron/windows/gui/settings_window.py:193
+msgid "Copy Mode"
+msgstr "Copy Mode"
+
+#: auto_neutron/windows/gui/settings_window.py:194
+msgid "AHK Path"
+msgstr "AHK Path"
+
+#: auto_neutron/windows/gui/settings_window.py:195
+msgid "Auto scroll"
+msgstr "Auto scroll"
+
+#: auto_neutron/windows/gui/settings_window.py:197
+msgid "Taskbar fuel alert"
+msgstr "Taskbar fuel alert"
+
+#: auto_neutron/windows/gui/settings_window.py:198
+msgid "Sound fuel alert"
+msgstr "Sound fuel alert"
+
+#: auto_neutron/windows/gui/settings_window.py:199
+msgid "Custom sound alert file:"
+msgstr "Custom sound alert file:"
+
+#: auto_neutron/windows/gui/settings_window.py:201
+#, python-format
+msgid "%% of maximum fuel usage left in tank before triggering alert"
+msgstr "%% of maximum fuel usage left in tank before triggering alert"
+
+#: auto_neutron/windows/gui/settings_window.py:206
+msgid ""
+"Bind to trigger the script, # for win key, ! for alt, ^ for control, + "
+"for shift"
+msgstr ""
+"Bind to trigger the script, # for win key, ! for alt, ^ for control, + "
+"for shift"
+
+#: auto_neutron/windows/gui/shut_down_window.py:67
+msgid "Game shut down"
+msgstr "Game shut down"
+
+#: auto_neutron/windows/gui/shut_down_window.py:72
+msgid "New journal"
+msgstr "New journal"

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ import auto_neutron
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa F401
-from auto_neutron import hub
+from auto_neutron import hub, win_theme_change_listener
 from auto_neutron.constants import APP, APPID, ORG, VERSION, get_config_dir
 from auto_neutron.settings import set_settings
 from auto_neutron.settings.toml_settings import TOMLSettings
@@ -89,5 +89,6 @@ sys.excepthook = ex_handler.handler
 
 set_settings(TOMLSettings((get_config_dir() / "config.toml")))
 root_logger.info(f"Starting Auto_Neutron ver {VERSION}")
-hub = hub.Hub(ex_handler)
-sys.exit(app.exec())
+with win_theme_change_listener.create_listener() as listener:
+    hub = hub.Hub(ex_handler, listener)
+    sys.exit(app.exec())

--- a/main.py
+++ b/main.py
@@ -86,7 +86,6 @@ sys.excepthook = ex_handler.handler
 
 set_settings(TOMLSettings((get_config_dir() / "config.toml")))
 auto_neutron.locale.set_active_locale(babel.Locale.parse(General.locale))
-auto_neutron.locale.install_translation(General.locale)
 root_logger.info(f"Starting Auto_Neutron ver {VERSION}")
 with win_theme_change_listener.create_listener() as listener:
     hub = hub.Hub(ex_handler, listener)

--- a/main.py
+++ b/main.py
@@ -22,15 +22,16 @@ import sys
 from logging import handlers
 from pathlib import Path
 
+import babel
 from PySide6 import QtGui, QtNetwork, QtWidgets
 
-import auto_neutron
+import auto_neutron.locale
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa F401
 from auto_neutron import hub, win_theme_change_listener
 from auto_neutron.constants import APP, APPID, ORG, VERSION, get_config_dir
-from auto_neutron.settings import set_settings
+from auto_neutron.settings import General, set_settings
 from auto_neutron.settings.toml_settings import TOMLSettings
 from auto_neutron.utils.file import base_path
 from auto_neutron.utils.logging import (
@@ -84,6 +85,8 @@ ex_handler = ExceptionHandler()
 sys.excepthook = ex_handler.handler
 
 set_settings(TOMLSettings((get_config_dir() / "config.toml")))
+auto_neutron.locale.set_active_locale(babel.Locale.parse(General.locale))
+auto_neutron.locale.install_translation(General.locale)
 root_logger.info(f"Starting Auto_Neutron ver {VERSION}")
 with win_theme_change_listener.create_listener() as listener:
     hub = hub.Hub(ex_handler, listener)

--- a/main.py
+++ b/main.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Auto_Neutron.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import ctypes
 import logging
 import sys

--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ if __debug__:
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setFormatter(log_format)
     root_logger.addHandler(stream_handler)
-    qt_interrupt_timer = create_interrupt_timer()
+    qt_interrupt_timer = create_interrupt_timer(app)
 
     logger_path = Path("logs/log.log")
     logger_path.parent.mkdir(exist_ok=True)

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ from auto_neutron import hub, win_theme_change_listener
 from auto_neutron.constants import APP, APPID, ORG, VERSION, get_config_dir
 from auto_neutron.settings import set_settings
 from auto_neutron.settings.toml_settings import TOMLSettings
+from auto_neutron.utils.file import base_path
 from auto_neutron.utils.logging import (
     SessionBackupHandler,
     UsernameFormatter,
@@ -39,16 +40,9 @@ from auto_neutron.utils.logging import (
 )
 from auto_neutron.utils.utils import ExceptionHandler, create_interrupt_timer
 
-
-def resource_path(relative_path: Path) -> str:
-    """Get absolute path to resource, using pyinstaller's temp directory when built."""
-    base_path = getattr(sys, "_MEIPASS", Path(__file__).parent / "resources")
-    return str(base_path / relative_path)
-
-
 ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(APPID)
 app = QtWidgets.QApplication(sys.argv)
-app.window_icon = QtGui.QIcon(resource_path(Path("icons_library.ico")))
+app.window_icon = QtGui.QIcon(str(base_path() / "resources/icons_library.ico"))
 app.application_name = APP
 app.organization_name = ORG
 app.set_style("Fusion")

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,29 +8,17 @@ python-versions = "*"
 
 [[package]]
 name = "attrs"
-version = "21.2.0"
+version = "21.3.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
-
-[[package]]
-name = "backports.entry-points-selectable"
-version = "1.1.1"
-description = "Compatibility shim providing selectable entry points for older implementations"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
 name = "bandit"
@@ -106,11 +94,11 @@ python-versions = "*"
 
 [[package]]
 name = "filelock"
-version = "3.4.0"
+version = "3.4.2"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -254,7 +242,7 @@ typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.10\"
 
 [[package]]
 name = "identify"
-version = "2.4.0"
+version = "2.4.1"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -349,11 +337,11 @@ future = "*"
 
 [[package]]
 name = "platformdirs"
-version = "2.4.0"
+version = "2.4.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -563,7 +551,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "tomli"
 version = "1.2.3"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -571,7 +559,7 @@ python-versions = ">=3.6"
 name = "tomli-w"
 version = "1.0.0"
 description = "A lil' TOML writer"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -585,14 +573,13 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "virtualenv"
-version = "20.10.0"
+version = "20.11.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
-"backports.entry-points-selectable" = ">=1.0.4"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.2,<4"
 platformdirs = ">=2,<3"
@@ -605,7 +592,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.*"
-content-hash = "f1e0961150dacc3ee09148d8b6a462f3a2a8c3d7ddae37d9eadd00ed2a40d40d"
+content-hash = "2f6f4976f5afcf2bef8ed621ebbf13f3013794d5345acbd21a0af531c3840d91"
 
 [metadata.files]
 altgraph = [
@@ -613,12 +600,8 @@ altgraph = [
     {file = "altgraph-0.17.2.tar.gz", hash = "sha256:ebf2269361b47d97b3b88e696439f6e4cbc607c17c51feb1754f90fb79839158"},
 ]
 attrs = [
-    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
-    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
-]
-"backports.entry-points-selectable" = [
-    {file = "backports.entry_points_selectable-1.1.1-py2.py3-none-any.whl", hash = "sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b"},
-    {file = "backports.entry_points_selectable-1.1.1.tar.gz", hash = "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"},
+    {file = "attrs-21.3.0-py2.py3-none-any.whl", hash = "sha256:8f7335278dedd26b58c38e006338242cc0977f06d51579b2b8b87b9b33bff66c"},
+    {file = "attrs-21.3.0.tar.gz", hash = "sha256:50f3c9b216dc9021042f71b392859a773b904ce1a029077f58f6598272432045"},
 ]
 bandit = [
     {file = "bandit-1.7.1-py3-none-any.whl", hash = "sha256:f5acd838e59c038a159b5c621cf0f8270b279e884eadd7b782d7491c02add0d4"},
@@ -645,8 +628,8 @@ distlib = [
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
 filelock = [
-    {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
-    {file = "filelock-3.4.0.tar.gz", hash = "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"},
+    {file = "filelock-3.4.2-py3-none-any.whl", hash = "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"},
+    {file = "filelock-3.4.2.tar.gz", hash = "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
@@ -691,8 +674,8 @@ gitpython = [
     {file = "GitPython-3.1.24.tar.gz", hash = "sha256:df83fdf5e684fef7c6ee2c02fc68a5ceb7e7e759d08b694088d0cacb4eba59e5"},
 ]
 identify = [
-    {file = "identify-2.4.0-py2.py3-none-any.whl", hash = "sha256:eba31ca80258de6bb51453084bff4a923187cd2193b9c13710f2516ab30732cc"},
-    {file = "identify-2.4.0.tar.gz", hash = "sha256:a33ae873287e81651c7800ca309dc1f84679b763c9c8b30680e16fbfa82f0107"},
+    {file = "identify-2.4.1-py2.py3-none-any.whl", hash = "sha256:0192893ff68b03d37fed553e261d4a22f94ea974093aefb33b29df2ff35fed3c"},
+    {file = "identify-2.4.1.tar.gz", hash = "sha256:64d4885e539f505dd8ffb5e93c142a1db45480452b1594cacd3e91dca9a984e9"},
 ]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
@@ -730,8 +713,8 @@ pefile = [
     {file = "pefile-2021.9.3.tar.gz", hash = "sha256:344a49e40a94e10849f0fe34dddc80f773a12b40675bf2f7be4b8be578bdd94a"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
-    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+    {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
+    {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
 pre-commit = [
     {file = "pre_commit-2.16.0-py2.py3-none-any.whl", hash = "sha256:758d1dc9b62c2ed8881585c254976d66eae0889919ab9b859064fc2fe3c7743e"},
@@ -888,6 +871,6 @@ typing-extensions = [
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.10.0-py2.py3-none-any.whl", hash = "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814"},
-    {file = "virtualenv-20.10.0.tar.gz", hash = "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"},
+    {file = "virtualenv-20.11.0-py2.py3-none-any.whl", hash = "sha256:eb0cb34160f32c6596405308ee6a8a4abbf3247b2b9794ae655a156d43abf48e"},
+    {file = "virtualenv-20.11.0.tar.gz", hash = "sha256:2f15b9226cb74b59c21e8236dd791c395bee08cdd33b99cddd18e1f866cdb098"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,17 +8,17 @@ python-versions = "*"
 
 [[package]]
 name = "attrs"
-version = "21.3.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "bandit"
@@ -573,7 +573,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "virtualenv"
-version = "20.11.0"
+version = "20.11.2"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -592,7 +592,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.*"
-content-hash = "2f6f4976f5afcf2bef8ed621ebbf13f3013794d5345acbd21a0af531c3840d91"
+content-hash = "9e3cee52d70659fd9c3b324374c362ef53fae0f430b074316463ed7cc1bd45f4"
 
 [metadata.files]
 altgraph = [
@@ -600,8 +600,8 @@ altgraph = [
     {file = "altgraph-0.17.2.tar.gz", hash = "sha256:ebf2269361b47d97b3b88e696439f6e4cbc607c17c51feb1754f90fb79839158"},
 ]
 attrs = [
-    {file = "attrs-21.3.0-py2.py3-none-any.whl", hash = "sha256:8f7335278dedd26b58c38e006338242cc0977f06d51579b2b8b87b9b33bff66c"},
-    {file = "attrs-21.3.0.tar.gz", hash = "sha256:50f3c9b216dc9021042f71b392859a773b904ce1a029077f58f6598272432045"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 bandit = [
     {file = "bandit-1.7.1-py3-none-any.whl", hash = "sha256:f5acd838e59c038a159b5c621cf0f8270b279e884eadd7b782d7491c02add0d4"},
@@ -871,6 +871,6 @@ typing-extensions = [
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.11.0-py2.py3-none-any.whl", hash = "sha256:eb0cb34160f32c6596405308ee6a8a4abbf3247b2b9794ae655a156d43abf48e"},
-    {file = "virtualenv-20.11.0.tar.gz", hash = "sha256:2f15b9226cb74b59c21e8236dd791c395bee08cdd33b99cddd18e1f866cdb098"},
+    {file = "virtualenv-20.11.2-py2.py3-none-any.whl", hash = "sha256:efd556cec612fd826dc7ef8ce26a6e4ba2395f494244919acd135fb5ceffa809"},
+    {file = "virtualenv-20.11.2.tar.gz", hash = "sha256:7f9e9c2e878d92a434e760058780b8d67a7c5ec016a66784fe4b0d5e50a4eb5c"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,17 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "babel"
+version = "2.9.1"
+description = "Internationalization utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pytz = ">=2015.7"
+
+[[package]]
 name = "bandit"
 version = "1.7.1"
 description = "Security oriented static analyser for python code."
@@ -365,7 +376,7 @@ virtualenv = ">=20.0.8"
 
 [[package]]
 name = "psutil"
-version = "5.8.0"
+version = "5.9.0"
 description = "Cross-platform lib for process and system monitoring in Python."
 category = "dev"
 optional = false
@@ -452,6 +463,14 @@ python-versions = ">=3.5"
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "pytz"
+version = "2021.3"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "pywin32-ctypes"
@@ -573,7 +592,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "virtualenv"
-version = "20.11.2"
+version = "20.13.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -592,7 +611,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.*"
-content-hash = "9e3cee52d70659fd9c3b324374c362ef53fae0f430b074316463ed7cc1bd45f4"
+content-hash = "158dfff8dbba67a2b3e7b8fd2a29fc54cf0da36c30e1015566804c9c6f3ead53"
 
 [metadata.files]
 altgraph = [
@@ -602,6 +621,10 @@ altgraph = [
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
+babel = [
+    {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},
+    {file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"},
 ]
 bandit = [
     {file = "bandit-1.7.1-py3-none-any.whl", hash = "sha256:f5acd838e59c038a159b5c621cf0f8270b279e884eadd7b782d7491c02add0d4"},
@@ -721,34 +744,33 @@ pre-commit = [
     {file = "pre_commit-2.16.0.tar.gz", hash = "sha256:fe9897cac830aa7164dbd02a4e7b90cae49630451ce88464bca73db486ba9f65"},
 ]
 psutil = [
-    {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},
-    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c"},
-    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df"},
-    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131"},
-    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60"},
-    {file = "psutil-5.8.0-cp27-none-win32.whl", hash = "sha256:ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876"},
-    {file = "psutil-5.8.0-cp27-none-win_amd64.whl", hash = "sha256:5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65"},
-    {file = "psutil-5.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8"},
-    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6"},
-    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac"},
-    {file = "psutil-5.8.0-cp36-cp36m-win32.whl", hash = "sha256:36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2"},
-    {file = "psutil-5.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d"},
-    {file = "psutil-5.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935"},
-    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d"},
-    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023"},
-    {file = "psutil-5.8.0-cp37-cp37m-win32.whl", hash = "sha256:1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394"},
-    {file = "psutil-5.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"},
-    {file = "psutil-5.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef"},
-    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28"},
-    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b"},
-    {file = "psutil-5.8.0-cp38-cp38-win32.whl", hash = "sha256:ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d"},
-    {file = "psutil-5.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d"},
-    {file = "psutil-5.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7"},
-    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4"},
-    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b"},
-    {file = "psutil-5.8.0-cp39-cp39-win32.whl", hash = "sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0"},
-    {file = "psutil-5.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3"},
-    {file = "psutil-5.8.0.tar.gz", hash = "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6"},
+    {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b"},
+    {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:7336292a13a80eb93c21f36bde4328aa748a04b68c13d01dfddd67fc13fd0618"},
+    {file = "psutil-5.9.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:cb8d10461c1ceee0c25a64f2dd54872b70b89c26419e147a05a10b753ad36ec2"},
+    {file = "psutil-5.9.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:7641300de73e4909e5d148e90cc3142fb890079e1525a840cf0dfd39195239fd"},
+    {file = "psutil-5.9.0-cp27-none-win32.whl", hash = "sha256:ea42d747c5f71b5ccaa6897b216a7dadb9f52c72a0fe2b872ef7d3e1eacf3ba3"},
+    {file = "psutil-5.9.0-cp27-none-win_amd64.whl", hash = "sha256:ef216cc9feb60634bda2f341a9559ac594e2eeaadd0ba187a4c2eb5b5d40b91c"},
+    {file = "psutil-5.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90a58b9fcae2dbfe4ba852b57bd4a1dded6b990a33d6428c7614b7d48eccb492"},
+    {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff0d41f8b3e9ebb6b6110057e40019a432e96aae2008951121ba4e56040b84f3"},
+    {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2"},
+    {file = "psutil-5.9.0-cp310-cp310-win32.whl", hash = "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d"},
+    {file = "psutil-5.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b"},
+    {file = "psutil-5.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0"},
+    {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce"},
+    {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5"},
+    {file = "psutil-5.9.0-cp37-cp37m-win32.whl", hash = "sha256:df2c8bd48fb83a8408c8390b143c6a6fa10cb1a674ca664954de193fdcab36a9"},
+    {file = "psutil-5.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1d7b433519b9a38192dfda962dd8f44446668c009833e1429a52424624f408b4"},
+    {file = "psutil-5.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c3400cae15bdb449d518545cbd5b649117de54e3596ded84aacabfbb3297ead2"},
+    {file = "psutil-5.9.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2237f35c4bbae932ee98902a08050a27821f8f6dfa880a47195e5993af4702d"},
+    {file = "psutil-5.9.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1070a9b287846a21a5d572d6dddd369517510b68710fca56b0e9e02fd24bed9a"},
+    {file = "psutil-5.9.0-cp38-cp38-win32.whl", hash = "sha256:76cebf84aac1d6da5b63df11fe0d377b46b7b500d892284068bacccf12f20666"},
+    {file = "psutil-5.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:3151a58f0fbd8942ba94f7c31c7e6b310d2989f4da74fcbf28b934374e9bf841"},
+    {file = "psutil-5.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:539e429da49c5d27d5a58e3563886057f8fc3868a5547b4f1876d9c0f007bccf"},
+    {file = "psutil-5.9.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58c7d923dc209225600aec73aa2c4ae8ea33b1ab31bc11ef8a5933b027476f07"},
+    {file = "psutil-5.9.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3611e87eea393f779a35b192b46a164b1d01167c9d323dda9b1e527ea69d697d"},
+    {file = "psutil-5.9.0-cp39-cp39-win32.whl", hash = "sha256:4e2fb92e3aeae3ec3b7b66c528981fd327fb93fd906a77215200404444ec1845"},
+    {file = "psutil-5.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:7d190ee2eaef7831163f254dc58f6d2e2a22e27382b936aab51c835fc080c3d3"},
+    {file = "psutil-5.9.0.tar.gz", hash = "sha256:869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
@@ -785,6 +807,10 @@ pyside6 = [
 python-dotenv = [
     {file = "python-dotenv-0.19.2.tar.gz", hash = "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"},
     {file = "python_dotenv-0.19.2-py2.py3-none-any.whl", hash = "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3"},
+]
+pytz = [
+    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
+    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
 ]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
@@ -871,6 +897,6 @@ typing-extensions = [
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.11.2-py2.py3-none-any.whl", hash = "sha256:efd556cec612fd826dc7ef8ce26a6e4ba2395f494244919acd135fb5ceffa809"},
-    {file = "virtualenv-20.11.2.tar.gz", hash = "sha256:7f9e9c2e878d92a434e760058780b8d67a7c5ec016a66784fe4b0d5e50a4eb5c"},
+    {file = "virtualenv-20.13.0-py2.py3-none-any.whl", hash = "sha256:339f16c4a86b44240ba7223d0f93a7887c3ca04b5f9c8129da7958447d079b09"},
+    {file = "virtualenv-20.13.0.tar.gz", hash = "sha256:d8458cf8d59d0ea495ad9b34c2599487f8a7772d796f9910858376d1600dd2dd"},
 ]

--- a/pyinstaller_build/Auto_Neutron.spec
+++ b/pyinstaller_build/Auto_Neutron.spec
@@ -8,6 +8,7 @@ a = Analysis(
     binaries=[],
     datas=[
         ("../resources/icons_library.ico", "./resources"),
+        ("../locale", "./locale"),
     ],
     hiddenimports=[],
     hookspath=[],

--- a/pyinstaller_build/Auto_Neutron.spec
+++ b/pyinstaller_build/Auto_Neutron.spec
@@ -7,7 +7,7 @@ a = Analysis(
     pathex=["."],
     binaries=[],
     datas=[
-        ("../resources/icons_library.ico", "."),
+        ("../resources/icons_library.ico", "./resources"),
     ],
     hiddenimports=[],
     hookspath=[],

--- a/pyinstaller_build/Auto_Neutron_debug.spec
+++ b/pyinstaller_build/Auto_Neutron_debug.spec
@@ -8,7 +8,7 @@ a = Analysis(
     pathex=["."],
     binaries=[],
     datas=[
-        ("../resources/icons_library.ico", "."),
+        ("../resources/icons_library.ico", "./resources"),
     ],
     hiddenimports=[],
     hookspath=[],

--- a/pyinstaller_build/Auto_Neutron_debug.spec
+++ b/pyinstaller_build/Auto_Neutron_debug.spec
@@ -9,6 +9,7 @@ a = Analysis(
     binaries=[],
     datas=[
         ("../resources/icons_library.ico", "./resources"),
+        ("../locale", "./locale"),
     ],
     hiddenimports=[],
     hookspath=[],

--- a/pyinstaller_build/Auto_Neutron_dir.spec
+++ b/pyinstaller_build/Auto_Neutron_dir.spec
@@ -8,7 +8,7 @@ a = Analysis(
     pathex=["."],
     binaries=[],
     datas=[
-        ("../resources/icons_library.ico", "."),
+        ("../resources/icons_library.ico", "./resources"),
     ],
     hiddenimports=[],
     hookspath=[],

--- a/pyinstaller_build/Auto_Neutron_dir.spec
+++ b/pyinstaller_build/Auto_Neutron_dir.spec
@@ -9,6 +9,7 @@ a = Analysis(
     binaries=[],
     datas=[
         ("../resources/icons_library.ico", "./resources"),
+        ("../locale", "./locale"),
     ],
     hiddenimports=[],
     hookspath=[],

--- a/pyinstaller_build/build.py
+++ b/pyinstaller_build/build.py
@@ -22,6 +22,12 @@ else:
     debug = True
 delete_dlls.main()
 
+compiled_process = subprocess.run(  # noqa: S603, S607
+    ["poetry", "run", "task", "i18n-compile"]
+)
+if compiled_process.returncode != 0:
+    raise Exception("Failed to compile translation files.")
+
 for spec_file in spec_files:
     PyInstaller.__main__.run(
         [

--- a/pyinstaller_build/build.py
+++ b/pyinstaller_build/build.py
@@ -4,6 +4,7 @@ import subprocess  # noqa S404
 import sys
 from pathlib import Path
 
+import delete_babel_dat
 import dotenv
 import PyInstaller.__main__
 
@@ -21,7 +22,7 @@ else:
     spec_files = ["pyinstaller_build/Auto_Neutron_debug.spec"]
     debug = True
 delete_dlls.main()
-
+delete_babel_dat.main()
 compiled_process = subprocess.run(  # noqa: S603, S607
     ["poetry", "run", "task", "i18n-compile"]
 )

--- a/pyinstaller_build/delete_babel_dat.py
+++ b/pyinstaller_build/delete_babel_dat.py
@@ -1,0 +1,31 @@
+# This file uses the MIT license.
+# Copyright (C) 2021  Numerlor
+
+"""Delete .dat locale data files from the babel install that aren't needed for this app."""
+
+import sys
+from pathlib import Path
+
+EXCLUDE_FILES = {"root.dat", "en.dat", "en_001.dat", "en_150.dat"}
+
+
+def get_locale_data_dir() -> Path:
+    """Get the babel locale-data dir site-packages path of the current interpreter."""
+    parent_dir = Path(sys.executable).parent
+    if parent_dir.name == "Scripts":
+        root_dir = parent_dir.parent
+    else:
+        root_dir = parent_dir
+    return root_dir / "Lib" / "site-packages" / "babel" / "locale-data"
+
+
+def main() -> None:
+    """Delete all the data files except the ones in EXCLUDE_FILES."""
+    locale_dir = get_locale_data_dir()
+    for file in locale_dir.glob("*"):
+        if file.name not in EXCLUDE_FILES:
+            file.unlink()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ tomli = "~1.2.3"
 tomli-w = "~1.0.0"
 
 [tool.poetry.dev-dependencies]
+typing-extensions = ">=4.0.1"
 flake8 = "~4.0"
 flake8-annotations = "~2.7"
 flake8-bandit = "~2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,8 @@ lint = "pre-commit run --all-files"
 pyside-pyi = "pyside6-genpyi all --feature snake_case true_property"
 build = "python -OO pyinstaller_build/build.py"
 build_debug = "python pyinstaller_build/build.py"
+
+i18n-init = "pybabel init -i .\\locale\\auto_neutron.pot -d .\\locale -D auto_neutron -l"
+i18n-compile = "pybabel compile -d locale -D auto_neutron"
+i18n-update = "pybabel update -i .\\locale\\auto_neutron.pot -d .\\locale -D auto_neutron"
+i18n-extract = "pybabel extract auto_neutron -o locale/auto_neutron.pot -c NOTE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,11 @@ license = "GPL-3.0-or-later"
 python = "3.9.*"
 
 PySide6 = "~6.2.0"
+tomli = "~1.2.3"
+tomli-w = "~1.0.0"
 
 [tool.poetry.dev-dependencies]
-# Base tools
 flake8 = "~4.0"
-
 flake8-annotations = "~2.7"
 flake8-bandit = "~2.1"
 flake8-bugbear = "21.11.29"
@@ -26,8 +26,6 @@ pre-commit = "~2.16"
 pyinstaller = "~4.7"
 taskipy = "~1.9"
 python-dotenv = "~0.19.2"
-tomli = "~1.2.2"
-tomli-w = "~1.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Auto_Neutron"
-version = "2.0.2"
+version = "2.0.3"
 description = "An automatic neutron route plotter for Elite Dangerous"
 authors = ["Numerlor <numerlor@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "3.9.*"
 PySide6 = "~6.2.0"
 tomli = "~1.2.3"
 tomli-w = "~1.0.0"
+babel = "~2.9.1"
 
 [tool.poetry.dev-dependencies]
 typing-extensions = ">=4.0.1"

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ docstring-convention = all
 import-order-style = pycharm
 application-import-names = auto_neutron
 exclude = .idea/,pyinstaller_build/,.venv/
+builtins = _,
 ignore =
     S101,W503,E226,S311,T000
 # Missing Docstrings


### PR DESCRIPTION
- Make TooltipSlider's (LabeledSlider) value tooltip editable to manually set the value in case of a large slider
- Use project wide copyright year
- Fix readme string pointing user to Show more instead of More info
- Restructure modules to be under GUI in some case
- Add ability to use OS' theme by listening for changes through the WinThemeChangeListener
- Display saved route information to the user in its tab
- Correctly handle tristate checkboxes in settings
- Remove auto default buttons from dialogs
- Assign Hub as parent for ExceptionHandler to manage its lifetime properly
- Every typehint only import is not under TYPE_CHECKING and all modules that don't use annotations at runtime use the annotations future import
- Fix tomli dep by moving it to main deps
- text i18n through babel, numbers and others to come
- when starting a new route, if current system is on that route, move the route position to it