### PR TITLE
2.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Example of AHK script in action, with no user keyboard input apart from the hotk
 
 ![](https://i.imgur.com/ciZ5iQW.jpg)
 
-![](https://i.imgur.com/kTagchR.png)
+![](https://i.imgur.com/xzq2L1U.png)
 
 ## Features
 
@@ -29,7 +29,10 @@ On the initial launch, Windows will warn you about this being an untrusted appli
 
 ## Usage
 
-On launch, the app will display a popup that allows you to create a new route, either from a CSV file, Spansh, or a previously saved route.\
+On launch, the app will display a popup that allows you to create a new route, either from a CSV file, Spansh, or a previously saved route.
+
+The dropdown list at the bottom left lets you select the journal to follow for the route. If you started a new game while the window is open, you can press the refresh button next to it to refresh the available journals.
+
 After creating a route, the popup will close and the main window will be filled with route entries, and the plotter will start.\
 When you reach a system in the route, Auto_Neutron will either copy the next system into the clipboard, or it'll feed it to AHK.
 

--- a/auto_neutron/constants.py
+++ b/auto_neutron/constants.py
@@ -13,7 +13,7 @@ from PySide6 import QtCore
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
 
-VERSION = "v2.0.9"
+VERSION = "v2.1.0"
 APP = "Auto_Neutron"
 ORG = "Numerlor"
 APPID = f"{ORG}|{APP}|{VERSION}"

--- a/auto_neutron/dark_theme.py
+++ b/auto_neutron/dark_theme.py
@@ -1,0 +1,75 @@
+# This file is part of Auto_Neutron.
+# Copyright (C) 2019  Numerlor
+
+import functools
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+# noinspection PyUnresolvedReferences
+from __feature__ import snake_case, true_property  # noqa: F401
+
+
+class _ThemeSelector:
+    """Allow changing the app's theme through the `set_theme` method."""
+
+    # The palettes are cached because of a bug where reapplying the same dark palette but as a new QPalette instance
+    # caused the app's style to revert back to the default instead of being unchanged.
+
+    def set_theme(self, is_dark: bool) -> None:
+        """Set the app's theme depending on `is_dark`."""
+        if is_dark:
+            self._app.set_palette(self._dark_palette)
+        else:
+            self._app.set_palette(self._light_palette)
+
+    @functools.cached_property
+    def _dark_palette(self) -> QtGui.QPalette:
+        """Create a dark themed palette."""
+        p = QtGui.QPalette()
+        p.set_color(QtGui.QPalette.Window, QtGui.QColor(35, 35, 35))
+        p.set_color(QtGui.QPalette.WindowText, QtGui.QColor(247, 247, 247))
+        p.set_color(QtGui.QPalette.Base, QtGui.QColor(25, 25, 25))
+        p.set_color(QtGui.QPalette.Text, QtGui.QColor(247, 247, 247))
+        p.set_color(QtGui.QPalette.Button, QtGui.QColor(60, 60, 60))
+        p.set_color(QtGui.QPalette.AlternateBase, QtGui.QColor(45, 45, 45))
+        p.set_color(QtGui.QPalette.ToolTipText, QtCore.Qt.white)
+        p.set_color(QtGui.QPalette.ButtonText, QtCore.Qt.white)
+        p.set_color(QtGui.QPalette.PlaceholderText, QtGui.QColor(110, 110, 100))
+        p.set_color(QtGui.QPalette.Link, QtGui.QColor(0, 123, 255))
+        p.set_color(
+            QtGui.QPalette.Disabled,
+            QtGui.QPalette.Light,
+            QtGui.QColor(0, 0, 0),
+        )
+        p.set_color(
+            QtGui.QPalette.Disabled,
+            QtGui.QPalette.Text,
+            QtGui.QColor(110, 110, 100),
+        )
+        p.set_color(
+            QtGui.QPalette.Disabled,
+            QtGui.QPalette.ButtonText,
+            QtGui.QColor(110, 110, 100),
+        )
+        p.set_color(
+            QtGui.QPalette.Disabled,
+            QtGui.QPalette.Button,
+            QtGui.QColor(50, 50, 50),
+        )
+
+        return p
+
+    @functools.cached_property
+    def _light_palette(self) -> QtGui.QPalette:
+        """Create a light themed palette."""
+        p = self._app.style().standard_palette()
+        p.set_color(QtGui.QPalette.Link, QtGui.QColor(0, 123, 255))
+        return p
+
+    @functools.cached_property
+    def _app(self) -> QtWidgets.QApplication:
+        """Get the application's instance."""
+        return QtWidgets.QApplication.instance()
+
+
+set_theme = _ThemeSelector().set_theme

--- a/auto_neutron/dark_theme.py
+++ b/auto_neutron/dark_theme.py
@@ -15,12 +15,16 @@ class _ThemeSelector:
     # The palettes are cached because of a bug where reapplying the same dark palette but as a new QPalette instance
     # caused the app's style to revert back to the default instead of being unchanged.
 
+    def __init__(self):
+        self.is_dark = False
+
     def set_theme(self, is_dark: bool) -> None:
         """Set the app's theme depending on `is_dark`."""
         if is_dark:
             self._app.set_palette(self._dark_palette)
         else:
             self._app.set_palette(self._light_palette)
+        self.is_dark = is_dark
 
     @functools.cached_property
     def _dark_palette(self) -> QtGui.QPalette:
@@ -72,4 +76,10 @@ class _ThemeSelector:
         return QtWidgets.QApplication.instance()
 
 
-set_theme = _ThemeSelector().set_theme
+selector = _ThemeSelector()
+set_theme = selector.set_theme
+
+
+def is_dark() -> bool:
+    """Return True if the app is using the dark theme, False otherwise."""
+    return selector.is_dark

--- a/auto_neutron/fuel_warn.py
+++ b/auto_neutron/fuel_warn.py
@@ -42,7 +42,7 @@ class FuelWarn(QtCore.QObject):
 
     def warn(self, status_dict: dict) -> None:
         """Execute alert when in supercruise, on FSD cool down and fuel is below threshold."""
-        if self._journal.ship is None and not status_dict or "Fuel" not in status_dict:
+        if self._journal.ship is None or "Fuel" not in status_dict:
             # Sometimes we get empty JSON,
             # or when the game is shut down it only contains data up to flags.
             return

--- a/auto_neutron/fuel_warn.py
+++ b/auto_neutron/fuel_warn.py
@@ -42,11 +42,7 @@ class FuelWarn(QtCore.QObject):
 
     def warn(self, status_dict: dict) -> None:
         """Execute alert when in supercruise, on FSD cool down and fuel is below threshold."""
-        if (
-            not self._journal.ship.initialized
-            and not status_dict
-            or "Fuel" not in status_dict
-        ):
+        if self._journal.ship is None and not status_dict or "Fuel" not in status_dict:
             # Sometimes we get empty JSON,
             # or when the game is shut down it only contains data up to flags.
             return

--- a/auto_neutron/fuel_warn.py
+++ b/auto_neutron/fuel_warn.py
@@ -13,7 +13,7 @@ from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron import settings
 
 if t.TYPE_CHECKING:
-    from auto_neutron.hub import GameState
+    from auto_neutron.journal import Journal
 
 log = logging.getLogger(__name__)
 
@@ -27,20 +27,23 @@ class FuelWarn(QtCore.QObject):
     def __init__(
         self,
         parent: QtCore.QObject,
-        game_state: GameState,
         alert_widget: QtWidgets.QWidget,
     ):
         super().__init__(parent)
         self._warned = False
         self._alert_widget = alert_widget
-        self._game_state = game_state
+        self._journal = None
         self.player = QtMultimedia.QMediaPlayer(self)
         self.player.audio_output = self.audio_output = QtMultimedia.QAudioOutput(self)
+
+    def set_journal(self, journal: Journal) -> None:
+        """Set the journal to get the ship values from."""
+        self._journal = journal
 
     def warn(self, status_dict: dict) -> None:
         """Execute alert when in supercruise, on FSD cool down and fuel is below threshold."""
         if (
-            not self._game_state.ship.initialized
+            not self._journal.ship.initialized
             and not status_dict
             or "Fuel" not in status_dict
         ):
@@ -50,7 +53,7 @@ class FuelWarn(QtCore.QObject):
 
         status_flags = status_dict["Flags"]
         fuel_threshold = (
-            self._game_state.ship.fsd.max_fuel_usage * settings.Alerts.threshold / 100
+            self._journal.ship.fsd.max_fuel_usage * settings.Alerts.threshold / 100
         )
         if (
             not self._warned

--- a/auto_neutron/game_state.py
+++ b/auto_neutron/game_state.py
@@ -44,6 +44,7 @@ class PlotterState(QtCore.QObject):
         self._active_journal: Journal | None = None
         self._active_route: list | None = None
         self._plotter: Plotter | None = None
+        self._shut_down_connection = None
 
     def create_worker_with_route(self, route: RouteList) -> None:
         """
@@ -130,8 +131,13 @@ class PlotterState(QtCore.QObject):
         """
         self._active_journal = journal
         log.info("Setting new journal.")
+        if self._shut_down_connection is not None:
+            self.disconnect(self._shut_down_connection)
+
         if journal is not None:
-            journal.shut_down_sig.connect(self.shut_down_signal.emit)
+            self._shut_down_connection = journal.shut_down_sig.connect(
+                self.shut_down_signal.emit
+            )
             journal.parse()
 
             if self._plotter is not None:

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 
 import atexit
 import csv
-import functools
 import logging
 import typing as t
 from functools import partial
 
 import babel
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 import auto_neutron.locale
 
@@ -19,6 +18,7 @@ import auto_neutron.locale
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron import Theme, settings
 from auto_neutron.constants import JOURNAL_PATH, ROUTE_FILE_NAME, get_config_dir
+from auto_neutron.dark_theme import set_theme
 from auto_neutron.fuel_warn import FuelWarn
 from auto_neutron.game_state import PlotterState
 from auto_neutron.route_plots import AhkPlotter, CopyPlotter, NeutronPlotRow
@@ -259,69 +259,3 @@ class Hub(QtCore.QObject):
                 writer.writerows(row.to_csv() for row in self.plotter_state.route)
 
             settings.General.last_route_index = self.plotter_state.route_index
-
-
-class _ThemeSelector:
-    """Allow changing the app's theme through the `set_theme` method."""
-
-    # The palettes are cached because of a bug where reapplying the same dark palette but as a new QPalette instance
-    # caused the app's style to revert back to the default instead of being unchanged.
-
-    def set_theme(self, is_dark: bool) -> None:
-        """Set the app's theme depending on `is_dark`."""
-        if is_dark:
-            self._app.set_palette(self._dark_palette)
-        else:
-            self._app.set_palette(self._light_palette)
-
-    @functools.cached_property
-    def _dark_palette(self) -> QtGui.QPalette:
-        """Create a dark themed palette."""
-        p = QtGui.QPalette()
-        p.set_color(QtGui.QPalette.Window, QtGui.QColor(35, 35, 35))
-        p.set_color(QtGui.QPalette.WindowText, QtGui.QColor(247, 247, 247))
-        p.set_color(QtGui.QPalette.Base, QtGui.QColor(25, 25, 25))
-        p.set_color(QtGui.QPalette.Text, QtGui.QColor(247, 247, 247))
-        p.set_color(QtGui.QPalette.Button, QtGui.QColor(60, 60, 60))
-        p.set_color(QtGui.QPalette.AlternateBase, QtGui.QColor(45, 45, 45))
-        p.set_color(QtGui.QPalette.ToolTipText, QtCore.Qt.white)
-        p.set_color(QtGui.QPalette.ButtonText, QtCore.Qt.white)
-        p.set_color(QtGui.QPalette.PlaceholderText, QtGui.QColor(110, 110, 100))
-        p.set_color(QtGui.QPalette.Link, QtGui.QColor(0, 123, 255))
-        p.set_color(
-            QtGui.QPalette.Disabled,
-            QtGui.QPalette.Light,
-            QtGui.QColor(0, 0, 0),
-        )
-        p.set_color(
-            QtGui.QPalette.Disabled,
-            QtGui.QPalette.Text,
-            QtGui.QColor(110, 110, 100),
-        )
-        p.set_color(
-            QtGui.QPalette.Disabled,
-            QtGui.QPalette.ButtonText,
-            QtGui.QColor(110, 110, 100),
-        )
-        p.set_color(
-            QtGui.QPalette.Disabled,
-            QtGui.QPalette.Button,
-            QtGui.QColor(50, 50, 50),
-        )
-
-        return p
-
-    @functools.cached_property
-    def _light_palette(self) -> QtGui.QPalette:
-        """Create a light themed palette."""
-        p = self._app.style().standard_palette()
-        p.set_color(QtGui.QPalette.Link, QtGui.QColor(0, 123, 255))
-        return p
-
-    @functools.cached_property
-    def _app(self) -> QtWidgets.QApplication:
-        """Get the application's instance."""
-        return QtWidgets.QApplication.instance()
-
-
-set_theme = _ThemeSelector().set_theme

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -143,6 +143,10 @@ class Hub(QtCore.QObject):
         if route_index is None:
             logging.debug("Using current plotter index.")
             route_index = self.plotter_state.route_index
+
+        if route_index >= len(route):
+            route_index = len(route) - 1
+
         logging.debug(
             f"Creating a new {type(route[0]).__name__} route with {route_index=}."
         )

--- a/auto_neutron/hub.py
+++ b/auto_neutron/hub.py
@@ -25,13 +25,15 @@ from auto_neutron.route_plots import AhkPlotter, CopyPlotter, NeutronPlotRow
 from auto_neutron.self_updater import Updater
 from auto_neutron.settings import delay_sync
 from auto_neutron.utils.signal import ReconnectingSignal
-from auto_neutron.windows.error_window import ErrorWindow
-from auto_neutron.windows.license_window import LicenseWindow
-from auto_neutron.windows.main_window import MainWindow
-from auto_neutron.windows.missing_journal_window import MissingJournalWindow
-from auto_neutron.windows.new_route_window import NewRouteWindow
-from auto_neutron.windows.settings_window import SettingsWindow
-from auto_neutron.windows.shut_down_window import ShutDownWindow
+from auto_neutron.windows import (
+    ErrorWindow,
+    LicenseWindow,
+    MainWindow,
+    MissingJournalWindow,
+    NewRouteWindow,
+    SettingsWindow,
+    ShutDownWindow,
+)
 from auto_neutron.workers import StatusWorker
 
 if t.TYPE_CHECKING:

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -55,6 +55,7 @@ class Journal(QtCore.QObject):
             while True:
                 if line := journal_file.readline():
                     self._parse_journal_line(line)
+                    self._last_file_pos = journal_file.tell()
                 else:
                     yield
 

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -12,6 +12,7 @@ from PySide6 import QtCore
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron.game_state import Location
+from auto_neutron.ship import Ship
 from auto_neutron.utils.utils import get_sector_midpoint
 
 if t.TYPE_CHECKING:
@@ -27,13 +28,12 @@ class Journal(QtCore.QObject):
     system_sig = QtCore.Signal(Location)
     target_signal = QtCore.Signal(Location)
     loadout_sig = QtCore.Signal(dict)
-    cargo_sig = QtCore.Signal(int)
     shut_down_sig = QtCore.Signal()
 
     def __init__(self, journal_path: Path):
         super().__init__()
         self.path = journal_path
-        self.loadout = None
+        self.ship = Ship()
         self.location = None
         self.last_target = None
         self.cargo = None
@@ -69,7 +69,7 @@ class Journal(QtCore.QObject):
         """Parse a single line from the journal, setting attributes and emitting signals appropriately."""
         entry = json.loads(line)
         if entry["event"] == "Loadout":
-            self.loadout = entry
+            self.ship.update_from_loadout(entry)
             self.loadout_sig.emit(entry)
 
         elif entry["event"] == "Location" or entry["event"] == "FSDJump":

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -31,6 +31,7 @@ class Journal(QtCore.QObject):
 
     system_sig = QtCore.Signal(Location)
     target_signal = QtCore.Signal(Location)
+    cargo_signal = QtCore.Signal(int)
     loadout_sig = QtCore.Signal(dict)
     shut_down_sig = QtCore.Signal()
 
@@ -92,6 +93,7 @@ class Journal(QtCore.QObject):
 
         elif entry["event"] == "Cargo" and entry["Vessel"] == "Ship":
             self.cargo = entry["Count"]
+            self.cargo_signal.emit(self.cargo)
 
         elif entry["event"] == "Fileheader":
             self.is_oddysey = entry.get("Odyssey", False)

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -38,6 +38,8 @@ class Journal(QtCore.QObject):
         self.last_target = None
         self.cargo = None
         self.shut_down = False
+        self.is_oddysey = False
+        self.cmdr = None
 
         self._last_file_pos = 0
 
@@ -83,6 +85,12 @@ class Journal(QtCore.QObject):
 
         elif entry["event"] == "Cargo" and entry["Vessel"] == "Ship":
             self.cargo = entry["Count"]
+
+        elif entry["event"] == "Fileheader":
+            self.is_oddysey = entry.get("Odyssey", False)
+
+        elif entry["event"] == "Commander":
+            self.cmdr = entry["Name"]
 
         elif entry["event"] == "Shutdown":
             self.shut_down = True

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -54,8 +54,8 @@ class Journal(QtCore.QObject):
             journal_file.seek(0, 2)
             while True:
                 if line := journal_file.readline():
-                    self._parse_journal_line(line)
                     self._last_file_pos = journal_file.tell()
+                    self._parse_journal_line(line)
                 else:
                     yield
 
@@ -66,9 +66,9 @@ class Journal(QtCore.QObject):
         )
         with self.path.open(encoding="utf8") as journal_file:
             journal_file.seek(self._last_file_pos)
-            for line in journal_file:
+            while line := journal_file.readline():
+                self._last_file_pos = journal_file.tell()
                 self._parse_journal_line(line)
-            self._last_file_pos = journal_file.tell()
 
     def _parse_journal_line(self, line: str) -> None:
         """Parse a single line from the journal, setting attributes and emitting signals appropriately."""

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -49,7 +49,7 @@ class Journal(QtCore.QObject):
 
     def tail(self) -> collections.abc.Generator[None, None, None]:
         """Follow a log file, and emit signals for new systems, loadout changes and game shut down."""
-        log.info(f"Starting tailer of journal file at {self.path}.")
+        log.info(f"Starting tailer of journal file {self.path.name}.")
         with self.path.open(encoding="utf8") as journal_file:
             journal_file.seek(0, 2)
             while True:
@@ -62,7 +62,7 @@ class Journal(QtCore.QObject):
     def parse(self) -> None:
         """Parse the whole journal file and update the fields that were set."""
         log.info(
-            f"Statically parsing journal file at {self.path} from pos {self._last_file_pos}."
+            f"Statically parsing journal file {self.path.name} from pos {self._last_file_pos}."
         )
         with self.path.open(encoding="utf8") as journal_file:
             journal_file.seek(self._last_file_pos)

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -95,3 +95,22 @@ class Journal(QtCore.QObject):
         elif entry["event"] == "Shutdown":
             self.shut_down = True
             self.shut_down_sig.emit()
+
+
+journal_cache = {}
+
+
+def get_cached_journal(path: Path) -> Journal:
+    """
+    Get the journal object form `path`, if the journal was opened before, get the changed object.
+
+    The journal is parsed before being returned.
+    """
+    try:
+        journal = journal_cache[path]
+    except KeyError:
+        journal = journal_cache[path] = Journal(path)
+
+    journal.parse()
+
+    return journal

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -39,6 +39,8 @@ class Journal(QtCore.QObject):
         self.cargo = None
         self.shut_down = False
 
+        self._last_file_pos = 0
+
     def tail(self) -> collections.abc.Generator[None, None, None]:
         """Follow a log file, and emit signals for new systems, loadout changes and game shut down."""
         log.info(f"Starting tailer of journal file at {self.path}.")
@@ -52,10 +54,14 @@ class Journal(QtCore.QObject):
 
     def parse(self) -> None:
         """Parse the whole journal file and update the fields that were set."""
-        log.info(f"Statically parsing journal file at {self.path}.")
+        log.info(
+            f"Statically parsing journal file at {self.path} from pos {self._last_file_pos}."
+        )
         with self.path.open(encoding="utf8") as journal_file:
+            journal_file.seek(self._last_file_pos)
             for line in journal_file:
                 self._parse_journal_line(line)
+            self._last_file_pos = journal_file.tell()
 
     def _parse_journal_line(self, line: str) -> None:
         """Parse a single line from the journal, setting attributes and emitting signals appropriately."""

--- a/auto_neutron/journal.py
+++ b/auto_neutron/journal.py
@@ -37,7 +37,7 @@ class Journal(QtCore.QObject):
     def __init__(self, journal_path: Path):
         super().__init__()
         self.path = journal_path
-        self.ship = Ship()
+        self.ship = None
         self.location = None
         self.last_target = None
         self.cargo = None
@@ -73,6 +73,8 @@ class Journal(QtCore.QObject):
         """Parse a single line from the journal, setting attributes and emitting signals appropriately."""
         entry = json.loads(line)
         if entry["event"] == "Loadout":
+            if self.ship is None:
+                self.ship = Ship()
             self.ship.update_from_loadout(entry)
             self.loadout_sig.emit(entry)
 

--- a/auto_neutron/route_plots.py
+++ b/auto_neutron/route_plots.py
@@ -235,57 +235,6 @@ class AhkPlotter(Plotter):
                 log.warning(f"Unable to delete temp file at {temp_path}.")
 
 
-def _spansh_job_callback(
-    reply: QtNetwork.QNetworkReply,
-    *,
-    result_callback: collections.abc.Callable[[RouteList], t.Any],
-    error_callback: collections.abc.Callable[[str], t.Any],
-    delay_iterator: collections.abc.Iterator[float],
-    result_decode_func: collections.abc.Callable[[dict], t.Any],
-) -> None:
-    """
-    Handle a Spansh job reply, wait until a response is available and then return `result_decode_func` applied to it.
-
-    When re-requesting for status, wait for `delay` seconds,
-    where `delay` is the next value from the `delay_iterator`
-    """
-    try:
-        job_response = json_from_network_req(reply, json_error_key="error")
-    except NetworkError as e:
-        if e.reply_error is not None:
-            error_callback(_("Received error from Spansh: {}").format(e.reply_error))
-        else:
-            error_callback(
-                e.error_message
-            )  # Fall back to Qt error message if spansh didn't respond
-    except Exception as e:
-        error_callback(str(e))
-        logging.error(e)
-    else:
-        if job_response.get("status") == "queued":
-            sec_delay = next(delay_iterator)
-            log.debug(f"Re-requesting queued job result in {sec_delay} seconds.")
-            QtCore.QTimer.single_shot(
-                sec_delay * 1000,
-                partial(
-                    make_network_request,
-                    SPANSH_API_URL + "/results/" + job_response["job"],
-                    finished_callback=partial(
-                        _spansh_job_callback,
-                        result_callback=result_callback,
-                        error_callback=error_callback,
-                        delay_iterator=delay_iterator,
-                        result_decode_func=result_decode_func,
-                    ),
-                ),
-            )
-        elif job_response.get("result") is not None:
-            log.debug("Received finished neutron job.")
-            result_callback(result_decode_func(job_response["result"]))
-        else:
-            error_callback(_("Received invalid response from Spansh."))
-
-
 def _decode_neutron_result(result: dict) -> list[NeutronPlotRow]:
     return [
         NeutronPlotRow(
@@ -311,9 +260,91 @@ def _decode_exact_result(result: dict) -> list[ExactPlotRow]:
     ]
 
 
-spansh_neutron_callback = partial(
-    _spansh_job_callback, result_decode_func=_decode_neutron_result
-)
-spansh_exact_callback = partial(
-    _spansh_job_callback, result_decode_func=_decode_exact_result
-)
+class SpanshReplyTracker:
+    """Track the current reply from Spansh to allow termination."""
+
+    def __init__(self, parent: QtCore.QObject):
+        self._current_reply = None
+        self._delay_timer = QtCore.QTimer(parent)
+        self._delay_timer.single_shot_ = True
+        self._timer_connection = None
+
+    def _reply_callback(
+        self,
+        reply: QtNetwork.QNetworkReply,
+        *,
+        result_callback: collections.abc.Callable[[RouteList], t.Any],
+        error_callback: collections.abc.Callable[[str], t.Any],
+        delay_iterator: collections.abc.Iterator[float],
+        result_decode_func: collections.abc.Callable[[dict], t.Any],
+    ) -> None:
+        """
+        Handle a Spansh job reply, wait until a response is available and then return `result_decode_func` applied to it.
+
+        When re-requesting for status, wait for `delay` seconds,
+        where `delay` is the next value from the `delay_iterator`
+        """
+        self._reset_reply()
+        try:
+            job_response = json_from_network_req(reply, json_error_key="error")
+        except NetworkError as e:
+            if e.reply_error is not None:
+                error_callback(
+                    _("Received error from Spansh: {}").format(e.reply_error)
+                )
+            else:
+                error_callback(
+                    e.error_message
+                )  # Fall back to Qt error message if spansh didn't respond
+        except Exception as e:
+            error_callback(str(e))
+            logging.error(e)
+        else:
+            if job_response.get("status") == "queued":
+                sec_delay = next(delay_iterator)
+                log.debug(f"Re-requesting queued job result in {sec_delay} seconds.")
+                self._delay_timer.interval = 2000
+                self._timer_connection = self._delay_timer.timeout.connect(
+                    partial(
+                        self.make_request,
+                        SPANSH_API_URL + "/results/" + job_response["job"],
+                        finished_callback=partial(
+                            self._reply_callback,
+                            result_callback=result_callback,
+                            error_callback=error_callback,
+                            delay_iterator=delay_iterator,
+                            result_decode_func=result_decode_func,
+                        ),
+                    ),
+                )
+                self._delay_timer.start()
+            elif job_response.get("result") is not None:
+                log.debug("Received finished neutron job.")
+                result_callback(result_decode_func(job_response["result"]))
+            else:
+                error_callback(_("Received invalid response from Spansh."))
+
+    def spansh_exact_callback(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Callback to call the result callback with an ExactPlotRow list."""  # noqa: D401
+        self._reply_callback(*args, **kwargs, result_decode_func=_decode_exact_result)
+
+    def spansh_neutron_callback(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Callback to call the result callback with a NeutronPlotRow list."""  # noqa: D401
+        self._reply_callback(*args, **kwargs, result_decode_func=_decode_neutron_result)
+
+    def make_request(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Make a network request and store the result reply."""
+        self._current_reply = make_network_request(*args, **kwargs)
+
+    def abort(self) -> None:
+        """Abort the current request."""
+        log.debug("Aborting route plot request.")
+        if self._current_reply is not None:
+            self._current_reply.abort()
+        self._delay_timer.stop()
+
+    def _reset_reply(self) -> None:
+        """Reset the reply and disconnect the timer from the old make_request."""
+        self._current_reply = None
+        if self._timer_connection is not None:
+            self._delay_timer.disconnect(self._timer_connection)

--- a/auto_neutron/route_plots.py
+++ b/auto_neutron/route_plots.py
@@ -288,6 +288,12 @@ class SpanshReplyTracker:
         try:
             job_response = json_from_network_req(reply, json_error_key="error")
         except NetworkError as e:
+            if (
+                e.error_type
+                is QtNetwork.QNetworkReply.NetworkError.OperationCanceledError
+            ):
+                return
+
             if e.reply_error is not None:
                 error_callback(
                     _("Received error from Spansh: {}").format(e.reply_error)

--- a/auto_neutron/self_updater.py
+++ b/auto_neutron/self_updater.py
@@ -25,8 +25,7 @@ from auto_neutron.utils.network import (
     json_from_network_req,
     make_network_request,
 )
-from auto_neutron.windows.download_confirm_dialog import VersionDownloadConfirmDialog
-from auto_neutron.windows.update_error_window import UpdateErrorWindow
+from auto_neutron.windows import UpdateErrorWindow, VersionDownloadConfirmDialog
 
 log = logging.getLogger(__name__)
 

--- a/auto_neutron/ship.py
+++ b/auto_neutron/ship.py
@@ -21,7 +21,6 @@ class Ship:
         self.reserve_size: float | None = None
         self.unladen_mass: float | None = None
         self.max_cargo: int | None = None
-        self.initialized = False
 
     def jump_range(self, *, cargo_mass: int) -> float:
         """Calculate the jump range with `cargo_mass` t of cargo."""
@@ -48,7 +47,6 @@ class Ship:
         self.tank_size = int(loadout_dict["FuelCapacity"]["Main"])
         self.reserve_size = loadout_dict["FuelCapacity"]["Reserve"]
         self.max_cargo = loadout_dict["CargoCapacity"]
-        self.initialized = True
 
     @staticmethod
     def _fsd_from_loadout_dict(loadout: dict) -> FrameShiftDrive:
@@ -98,7 +96,6 @@ class Ship:
         self.tank_size = coriolis_json["stats"]["fuelCapacity"]
         self.reserve_size = coriolis_json["stats"]["reserveFuelCapacity"]
         self.max_cargo = coriolis_json["stats"]["cargoCapacity"]
-        self.initialized = True
 
     @classmethod
     def _fsd_from_coriolis_json(cls, json_data: dict) -> FrameShiftDrive:

--- a/auto_neutron/utils/utils.py
+++ b/auto_neutron/utils/utils.py
@@ -114,6 +114,6 @@ def _pop_n_lower_bits(number: int, n: int) -> tuple[int, int]:
 def cmdr_display_name(name: str | None) -> str:
     """Get the CMDR display name for `name`."""
     if name is not None:
-        return f"CMDR {name}"
+        return name
     else:
         return _("<Main menu>")

--- a/auto_neutron/utils/utils.py
+++ b/auto_neutron/utils/utils.py
@@ -109,3 +109,11 @@ def get_sector_midpoint(address: int) -> tuple[int, int, int]:
 def _pop_n_lower_bits(number: int, n: int) -> tuple[int, int]:
     """Get n lower-order bits from ˙number` and return the number without those bits, and the bits themselves."""
     return number >> n, number & (1 << n) - 1
+
+
+def cmdr_display_name(name: str | None) -> str:
+    """Get the CMDR display name for `name`."""
+    if name is not None:
+        return f"CMDR {name}"
+    else:
+        return "<No CMDR>"

--- a/auto_neutron/utils/utils.py
+++ b/auto_neutron/utils/utils.py
@@ -116,4 +116,4 @@ def cmdr_display_name(name: str | None) -> str:
     if name is not None:
         return f"CMDR {name}"
     else:
-        return "<No CMDR>"
+        return _("<Main menu>")

--- a/auto_neutron/windows/__init__.py
+++ b/auto_neutron/windows/__init__.py
@@ -1,0 +1,23 @@
+from .download_confirm_dialog import VersionDownloadConfirmDialog
+from .error_window import ErrorWindow
+from .license_window import LicenseWindow
+from .main_window import MainWindow
+from .missing_journal_window import MissingJournalWindow
+from .nearest_window import NearestWindow
+from .new_route_window import NewRouteWindow
+from .settings_window import SettingsWindow
+from .shut_down_window import ShutDownWindow
+from .update_error_window import UpdateErrorWindow
+
+__all__ = [
+    "VersionDownloadConfirmDialog",
+    "ErrorWindow",
+    "LicenseWindow",
+    "MainWindow",
+    "MissingJournalWindow",
+    "NearestWindow",
+    "NewRouteWindow",
+    "SettingsWindow",
+    "ShutDownWindow",
+    "UpdateErrorWindow",
+]

--- a/auto_neutron/windows/download_confirm_dialog.py
+++ b/auto_neutron/windows/download_confirm_dialog.py
@@ -11,9 +11,8 @@ from PySide6 import QtCore, QtWidgets
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron.constants import VERSION
 from auto_neutron.settings import General
-from auto_neutron.windows.gui.download_confirm_dialog import (
-    VersionDownloadConfirmDialogGUI,
-)
+
+from .gui.download_confirm_dialog import VersionDownloadConfirmDialogGUI
 
 
 class VersionDownloadConfirmDialog(VersionDownloadConfirmDialogGUI):

--- a/auto_neutron/windows/error_window.py
+++ b/auto_neutron/windows/error_window.py
@@ -12,7 +12,8 @@ from PySide6 import QtCore, QtGui, QtWidgets
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron.utils.file import get_file_name
-from auto_neutron.windows.gui.error_window import ErrorWindowGUI
+
+from .gui.error_window import ErrorWindowGUI
 
 root_logger = logging.getLogger()
 

--- a/auto_neutron/windows/gui/main_window.py
+++ b/auto_neutron/windows/gui/main_window.py
@@ -9,11 +9,8 @@ from PySide6 import QtCore, QtGui, QtWidgets
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
-from auto_neutron.windows.gui.delegates import (
-    CheckBoxDelegate,
-    DoubleSpinBoxDelegate,
-    SpinBoxDelegate,
-)
+
+from .delegates import CheckBoxDelegate, DoubleSpinBoxDelegate, SpinBoxDelegate
 
 if t.TYPE_CHECKING:
     import collections.abc

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -92,13 +92,6 @@ class TabBase(QtWidgets.QWidget):
 
         self.submit_button.text = _("Submit")
 
-        combo_items = (_("Last journal"), _("Second to last"), _("Third to last"))
-        if self.journal_combo.count == 0:
-            self.journal_combo.add_items(combo_items)
-        else:
-            for index, item in enumerate(combo_items):
-                self.journal_combo.set_item_text(index, item)
-
 
 class NeutronTab(TabBase):
     """The neutron plotter tab."""

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -312,10 +312,14 @@ class NewRouteWindowGUI(QtWidgets.QDialog):
         self.spansh_exact_tab = ExactTab(self.tab_widget)
         self.last_route_tab = LastTab(self.tab_widget)
 
-        self.tab_widget.add_tab(self.spansh_neutron_tab, "")
-        self.tab_widget.add_tab(self.spansh_exact_tab, "")
-        self.tab_widget.add_tab(self.csv_tab, "")
-        self.tab_widget.add_tab(self.last_route_tab, "")
+        self.tabs = (
+            self.spansh_neutron_tab,
+            self.spansh_exact_tab,
+            self.csv_tab,
+            self.last_route_tab,
+        )
+        for tab in self.tabs:
+            self.tab_widget.add_tab(tab, "")
 
         self.status_layout = QtWidgets.QHBoxLayout()
         self.status_widget = PlainTextScroller(self)
@@ -338,12 +342,7 @@ class NewRouteWindowGUI(QtWidgets.QDialog):
     def switch_submit_abort(self) -> None:
         """Switches the currently appearing submit/abort buttons for the other one."""
         abort_hidden = self.spansh_neutron_tab.abort_button.is_hidden()
-        for tab in (
-            self.spansh_neutron_tab,
-            self.spansh_exact_tab,
-            self.csv_tab,
-            self.last_route_tab,
-        ):
+        for tab in self.tabs:
             if abort_hidden:
                 tab.abort_button.show()
                 tab.submit_button.hide()

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -60,11 +60,10 @@ class TabBase(QtWidgets.QWidget):
         refresh_button = QtWidgets.QPushButton(widget_parent)
         refresh_button.icon = QtGui.QIcon(self.get_refresh_icon(is_dark()))
 
-        journal_submit_layout.add_widget(
-            journal_combo, alignment=QtCore.Qt.AlignmentFlag.AlignLeft
-        )
-        journal_submit_layout.add_widget(
-            refresh_button, alignment=QtCore.Qt.AlignmentFlag.AlignLeft
+        journal_submit_layout.add_widget(journal_combo)
+        journal_submit_layout.add_widget(refresh_button)
+        journal_submit_layout.add_spacer_item(
+            QtWidgets.QSpacerItem(1, 1, QtWidgets.QSizePolicy.Expanding)
         )
         journal_submit_layout.add_widget(submit_button)
 

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
-from PySide6 import QtCore, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa F401
+from auto_neutron.dark_theme import is_dark
+from auto_neutron.utils.file import base_path
 
 from .plain_text_scroller import PlainTextScroller
 from .tooltip_slider import TooltipSlider
@@ -30,12 +32,18 @@ class TabBase(QtWidgets.QWidget):
         (
             self.journal_submit_layout,
             self.journal_combo,
+            self.refresh_button,
             self.submit_button,
         ) = self.create_journal_and_submit_layout(self)
 
     def create_journal_and_submit_layout(
         self, widget_parent: QtWidgets.QWidget
-    ) -> tuple[QtWidgets.QHBoxLayout, QtWidgets.QComboBox, QtWidgets.QPushButton]:
+    ) -> tuple[
+        QtWidgets.QHBoxLayout,
+        QtWidgets.QComboBox,
+        QtWidgets.QPushButton,
+        QtWidgets.QPushButton,
+    ]:
         """Create a layout that holds the bottom journal combo box and submit button."""
         journal_submit_layout = QtWidgets.QHBoxLayout()
 
@@ -49,12 +57,22 @@ class TabBase(QtWidgets.QWidget):
             QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum
         )
 
+        refresh_button = QtWidgets.QPushButton(widget_parent)
+        refresh_button.icon = QtGui.QIcon(self.get_refresh_icon(is_dark()))
+
+        submit_button.size_policy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
+        )
+
         journal_submit_layout.add_widget(
             journal_combo, alignment=QtCore.Qt.AlignmentFlag.AlignLeft
         )
+        journal_submit_layout.add_widget(
+            refresh_button, alignment=QtCore.Qt.AlignmentFlag.AlignLeft
+        )
         journal_submit_layout.add_widget(submit_button)
 
-        return journal_submit_layout, journal_combo, submit_button
+        return journal_submit_layout, journal_combo, refresh_button, submit_button
 
     def create_system_and_cargo_layout(
         self, parent: QtWidgets.QWidget
@@ -82,6 +100,21 @@ class TabBase(QtWidgets.QWidget):
 
         return layout, source_system_edit, target_system_edit, cargo_label, cargo_slider
 
+    def get_refresh_icon(self, dark: bool) -> QtGui.QIcon:
+        """Get an appropriately coloured refresh icon."""
+        if dark:
+            path = base_path() / "resources/refresh-dark.svg"
+        else:
+            path = base_path() / "resources/refresh.svg"
+        return QtGui.QIcon(str(path))
+
+    def change_event(self, event: QtCore.QEvent) -> None:
+        """Update the tooltip's colors when the palette changes."""
+        if event.type() == QtCore.QEvent.Type.PaletteChange:
+            self.refresh_button.icon = self.get_refresh_icon(is_dark())
+
+        super().change_event(event)
+
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""
         if self.has_cargo:
@@ -91,6 +124,7 @@ class TabBase(QtWidgets.QWidget):
             self.cargo_label.text = _("Cargo")
 
         self.submit_button.text = _("Submit")
+        self.refresh_button.tool_tip = _("Refresh journals")
 
 
 class NeutronTab(TabBase):

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -60,10 +60,6 @@ class TabBase(QtWidgets.QWidget):
         refresh_button = QtWidgets.QPushButton(widget_parent)
         refresh_button.icon = QtGui.QIcon(self.get_refresh_icon(is_dark()))
 
-        submit_button.size_policy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
-        )
-
         journal_submit_layout.add_widget(
             journal_combo, alignment=QtCore.Qt.AlignmentFlag.AlignLeft
         )

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -258,7 +258,7 @@ class CSVTab(TabBase):
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""
         super().retranslate()
-        self.path_edit.placeholder_text = "CSV path"
+        self.path_edit.placeholder_text = _("CSV path")
 
 
 class LastTab(TabBase):

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -302,9 +302,9 @@ class NewRouteWindowGUI(QtWidgets.QDialog):
         self.spansh_exact_tab = ExactTab(self.tab_widget)
         self.last_route_tab = LastTab(self.tab_widget)
 
-        self.tab_widget.add_tab(self.csv_tab, "")
         self.tab_widget.add_tab(self.spansh_neutron_tab, "")
         self.tab_widget.add_tab(self.spansh_exact_tab, "")
+        self.tab_widget.add_tab(self.csv_tab, "")
         self.tab_widget.add_tab(self.last_route_tab, "")
 
         self.status_layout = QtWidgets.QHBoxLayout()
@@ -331,7 +331,7 @@ class NewRouteWindowGUI(QtWidgets.QDialog):
         self.spansh_neutron_tab.retranslate()
         self.spansh_exact_tab.retranslate()
         self.last_route_tab.retranslate()
-        self.tab_widget.set_tab_text(0, _("CSV"))
-        self.tab_widget.set_tab_text(1, _("Neutron plotter"))
-        self.tab_widget.set_tab_text(2, _("Galaxy plotter"))
+        self.tab_widget.set_tab_text(0, _("Neutron plotter"))
+        self.tab_widget.set_tab_text(1, _("Galaxy plotter"))
+        self.tab_widget.set_tab_text(2, _("CSV"))
         self.tab_widget.set_tab_text(3, _("Saved route"))

--- a/auto_neutron/windows/gui/new_route_window.py
+++ b/auto_neutron/windows/gui/new_route_window.py
@@ -34,6 +34,7 @@ class TabBase(QtWidgets.QWidget):
             self.journal_combo,
             self.refresh_button,
             self.submit_button,
+            self.abort_button,
         ) = self.create_journal_and_submit_layout(self)
 
     def create_journal_and_submit_layout(
@@ -41,6 +42,7 @@ class TabBase(QtWidgets.QWidget):
     ) -> tuple[
         QtWidgets.QHBoxLayout,
         QtWidgets.QComboBox,
+        QtWidgets.QPushButton,
         QtWidgets.QPushButton,
         QtWidgets.QPushButton,
     ]:
@@ -56,7 +58,11 @@ class TabBase(QtWidgets.QWidget):
         submit_button.size_policy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum
         )
-
+        abort_button = QtWidgets.QPushButton(widget_parent)
+        abort_button.size_policy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum
+        )
+        abort_button.hide()
         refresh_button = QtWidgets.QPushButton(widget_parent)
         refresh_button.icon = QtGui.QIcon(self.get_refresh_icon(is_dark()))
 
@@ -66,8 +72,15 @@ class TabBase(QtWidgets.QWidget):
             QtWidgets.QSpacerItem(1, 1, QtWidgets.QSizePolicy.Expanding)
         )
         journal_submit_layout.add_widget(submit_button)
+        journal_submit_layout.add_widget(abort_button)
 
-        return journal_submit_layout, journal_combo, refresh_button, submit_button
+        return (
+            journal_submit_layout,
+            journal_combo,
+            refresh_button,
+            submit_button,
+            abort_button,
+        )
 
     def create_system_and_cargo_layout(
         self, parent: QtWidgets.QWidget
@@ -119,6 +132,8 @@ class TabBase(QtWidgets.QWidget):
             self.cargo_label.text = _("Cargo")
 
         self.submit_button.text = _("Submit")
+        self.abort_button.text = _("Abort")
+        self.abort_button.tool_tip = _("Cancel the current route plot")
         self.refresh_button.tool_tip = _("Refresh journals")
 
 
@@ -319,6 +334,22 @@ class NewRouteWindowGUI(QtWidgets.QDialog):
             button.auto_default = False
 
         self.csv_tab.journal_combo.adjust_size()
+
+    def switch_submit_abort(self) -> None:
+        """Switches the currently appearing submit/abort buttons for the other one."""
+        abort_hidden = self.spansh_neutron_tab.abort_button.is_hidden()
+        for tab in (
+            self.spansh_neutron_tab,
+            self.spansh_exact_tab,
+            self.csv_tab,
+            self.last_route_tab,
+        ):
+            if abort_hidden:
+                tab.abort_button.show()
+                tab.submit_button.hide()
+            else:
+                tab.abort_button.hide()
+                tab.submit_button.show()
 
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""

--- a/auto_neutron/windows/gui/shut_down_window.py
+++ b/auto_neutron/windows/gui/shut_down_window.py
@@ -71,10 +71,3 @@ class ShutDownWindowGUI(QtWidgets.QDialog):
         self.new_journal_button.text = _("New journal")
         self.save_route_button.text = _("Save route")
         self.quit_button.text = _("Quit")
-
-        combo_items = (_("Last journal"), _("Second to last"), _("Third to last"))
-        if self.journal_combo.count == 0:
-            self.journal_combo.add_items(combo_items)
-        else:
-            for index, item in enumerate(combo_items):
-                self.journal_combo.set_item_text(index, item)

--- a/auto_neutron/windows/license_window.py
+++ b/auto_neutron/windows/license_window.py
@@ -25,6 +25,14 @@ class LicenseWindow(LicenseWindowGUI):
         super().__init__(parent)
         self.about_qt_button.pressed.connect(QtWidgets.QApplication.instance().about_qt)
         self.back_button.pressed.connect(self.retranslate)
+        self.back_button.pressed.connect(
+            lambda: setattr(self.back_button, "enabled", False)  # noqa: B010
+        )
+        self.text.sourceChanged.connect(
+            lambda: setattr(self.back_button, "enabled", True)  # noqa: B010
+        )
+
+        self.back_button.enabled = False
 
     def change_event(self, event: QtCore.QEvent) -> None:
         """Retranslate the GUI when a language change occurs."""

--- a/auto_neutron/windows/license_window.py
+++ b/auto_neutron/windows/license_window.py
@@ -41,6 +41,7 @@ class LicenseWindow(LicenseWindowGUI):
         mit_license_url = (base_path() / "resources/LICENSE_MIT.md").as_uri()
         bsd3_license_url = (base_path() / "resources/LICENSE_BSD_3_Clause.md").as_uri()
         gpl_license_url = (base_path() / "LICENSE.md").as_uri()
+        breeze_license_url = (base_path() / "resources/LICENSE_BREEZE.md").as_uri()
 
         return textwrap.dedent(
             _(
@@ -59,10 +60,15 @@ class LicenseWindow(LicenseWindowGUI):
 
         {python_copyright_notice}
           Python is licensed under the {psf_license_agreement_hyperlink}, see {python_licenses_hyperlink} for more details
+
+        And The Breeze Icons Theme Copyright (C) 2014 Uri Herrera <uri_herrera@nitrux.in> and others, under the {lgplv3_hyperlink}.
         """
             )
         ).format(
             gplv3_hyperlink=self.make_hyperlink(_("GPLv3 license"), gpl_license_url),
+            lgplv3_hyperlink=self.make_hyperlink(
+                _("LGPLv3 license"), breeze_license_url
+            ),
             gnu_licenses_hyperlink=self.make_hyperlink(
                 _("gnu.org/licenses"), GNU_LICENSES_URL
             ),

--- a/auto_neutron/windows/license_window.py
+++ b/auto_neutron/windows/license_window.py
@@ -11,7 +11,8 @@ from PySide6 import QtCore, QtWidgets
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
 from auto_neutron.utils.file import base_path
-from auto_neutron.windows.gui.license_window import LicenseWindowGUI
+
+from .gui.license_window import LicenseWindowGUI
 
 PYTHON_LICENSE_URL = "https://docs.python.org/3.10/license.html"
 GNU_LICENSES_URL = "https://www.gnu.org/licenses/"

--- a/auto_neutron/windows/main_window.py
+++ b/auto_neutron/windows/main_window.py
@@ -108,7 +108,7 @@ class MainWindow(MainWindowGUI):
             if self._current_route_type is ExactPlotRow:
                 self.table.horizontal_header_item(0).set_text(
                     # NOTE: made jumps/ total
-                    _("System name ({}/{})").format(index + 1, self.table.row_count)
+                    _("System name ({}/{})").format(index, self.table.row_count)
                 )
             else:
                 total_jumps = sum(

--- a/auto_neutron/windows/missing_journal_window.py
+++ b/auto_neutron/windows/missing_journal_window.py
@@ -7,7 +7,8 @@ from PySide6 import QtCore, QtWidgets
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
-from auto_neutron.windows.gui.missing_journal_window import MissingJournalWindowGUI
+
+from .gui.missing_journal_window import MissingJournalWindowGUI
 
 
 class MissingJournalWindow(MissingJournalWindowGUI):

--- a/auto_neutron/windows/nearest_window.py
+++ b/auto_neutron/windows/nearest_window.py
@@ -20,6 +20,8 @@ from auto_neutron.utils.network import (
 from .gui.nearest_window import NearestWindowGUI
 
 if t.TYPE_CHECKING:
+    import collections.abc
+
     from auto_neutron.game_state import Location
 
 
@@ -33,12 +35,13 @@ class NearestWindow(NearestWindowGUI):
         self,
         parent: QtWidgets.QWidget,
         start_location: Location,
-        status_bar: QtWidgets.QStatusBar,
+        status_callback: collections.abc.Callable[[str]]
+        | collections.abc.Callable[[str, int]],
     ):
         super().__init__(parent)
         self.set_input_values_from_location(start_location)
         self.search_button.pressed.connect(self._make_nearest_request)
-        self._parent_status_bar = status_bar
+        self._status_callback = status_callback
         self.retranslate()
 
     def set_input_values_from_location(self, location: Location | None) -> None:
@@ -74,7 +77,7 @@ class NearestWindow(NearestWindowGUI):
             else:
                 # Fall back to Qt error message if spansh didn't respond
                 message = e.error_message
-            self._parent_status_bar.show_message(message, 10_000)
+            self._status_callback.show_message(message, 10_000)
         else:
             self.system_name_result_label.text = data["system"]["name"]
             self.distance_result_label.text = (

--- a/auto_neutron/windows/nearest_window.py
+++ b/auto_neutron/windows/nearest_window.py
@@ -16,7 +16,8 @@ from auto_neutron.utils.network import (
     json_from_network_req,
     make_network_request,
 )
-from auto_neutron.windows.gui.nearest_window import NearestWindowGUI
+
+from .gui.nearest_window import NearestWindowGUI
 
 if t.TYPE_CHECKING:
     from auto_neutron.game_state import Location

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -267,6 +267,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         self.spansh_neutron_tab.submit_button.enabled = bool(
             self.spansh_neutron_tab.source_edit.text
             and self.spansh_neutron_tab.target_edit.text
+            and self.selected_journal is not None
         )
 
     def _set_exact_submit(self) -> None:
@@ -274,6 +275,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         self.spansh_exact_tab.submit_button.enabled = bool(
             self.spansh_exact_tab.source_edit.text
             and self.spansh_exact_tab.target_edit.text
+            and self.selected_journal is not None
             and (
                 self.selected_journal.ship is not None
                 or self.spansh_exact_tab.use_clipboard_checkbox.checked
@@ -450,6 +452,10 @@ class NewRouteWindow(NewRouteWindowGUI):
                     combo_box.clear()
                     combo_box.add_items(combo_items)
                 self._change_journal(0, show_change_message=show_change_message)
+                self.csv_tab.submit_button.enabled = True
+                self._set_neutron_submit()
+                self._set_exact_submit()
+                self.last_route_tab.submit_button.enabled = True
 
             else:
                 for combo_box in self._combo_boxes:
@@ -460,6 +466,11 @@ class NewRouteWindow(NewRouteWindowGUI):
                     _("Found no active journal files from within the last week."),
                     timeout=10_000,
                 )
+                self.csv_tab.submit_button.enabled = False
+                self.spansh_neutron_tab.submit_button.enabled = False
+                self.spansh_exact_tab.submit_button.enabled = False
+                self.last_route_tab.submit_button.enabled = False
+                self.selected_journal = None
 
     def _change_journal(self, index: int, *, show_change_message: bool = True) -> None:
         """Change the current journal and update the UI with its data, or display an error if shut down."""
@@ -505,11 +516,6 @@ class NewRouteWindow(NewRouteWindowGUI):
                 ),
                 timeout=5_000,
             )
-
-        self.csv_tab.submit_button.enabled = True
-        self._set_neutron_submit()
-        self._set_exact_submit()
-        self.last_route_tab.submit_button.enabled = True
 
     def _refresh_journals_on_shutdown(self) -> None:
         """Refresh the journal combo box and display a message saying that the selected journal got shut down."""

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -127,15 +127,12 @@ class NewRouteWindow(NewRouteWindowGUI):
             self.last_route_tab.refresh_button,
         ):
             button.pressed.connect(self._populate_journal_combos)
-            button.pressed.connect(partial(self._change_journal, 0))
 
         self.tab_widget.currentChanged.connect(self._display_saved_route)
         self._route_displayed = False
         self._loaded_route: list[NeutronPlotRow] | None = None
         self.retranslate()
         self._populate_journal_combos()
-        if self._journals:
-            self._change_journal(0)
 
     # region spansh plotters
     def _submit_neutron(self) -> None:
@@ -451,6 +448,7 @@ class NewRouteWindow(NewRouteWindowGUI):
                 for combo_box in self._combo_boxes:
                     combo_box.clear()
                     combo_box.add_items(combo_items)
+            self._change_journal(0)
         else:
             log.info("No valid journals found to populate combos with.")
             self._show_status_message(

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -500,6 +500,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         self.selected_journal.loadout_sig.connect(self._set_widget_values)
         self.selected_journal.system_sig.connect(self._set_widget_values)
         self.selected_journal.target_signal.connect(self._set_widget_values)
+        self.selected_journal.cargo_signal.connect(self._set_widget_values)
 
         if self._journal_worker is not None:
             self._journal_worker.stop()

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -125,6 +125,8 @@ class NewRouteWindow(NewRouteWindowGUI):
         self._loaded_route: list[NeutronPlotRow] | None = None
         self.retranslate()
         self._populate_journal_combos()
+        if self._journals:
+            self._change_journal(0)
 
     # region spansh plotters
     def _submit_neutron(self) -> None:

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -51,6 +51,7 @@ class NewRouteWindow(NewRouteWindowGUI):
     def __init__(self, parent: QtWidgets.QWidget):
         super().__init__(parent)
         self.selected_journal: Journal | None = None
+        self._journals = dict[Path, Journal]()
         self._journal_worker: GameWorker | None = None
         self._status_hide_timer = QtCore.QTimer(self)
         self._status_hide_timer.single_shot_ = True
@@ -429,8 +430,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         )
         journal_path = journals[min(index, len(journals) - 1)]
         log.info(f"Changing selected journal to {journal_path}.")
-        journal = Journal(journal_path)
-        journal.parse()
+        journal = self._get_journal(journal_path)
 
         self.selected_journal = journal
         if journal.shut_down:
@@ -469,6 +469,15 @@ class NewRouteWindow(NewRouteWindowGUI):
         self._set_neutron_submit()
         self._set_exact_submit()
         self.last_route_tab.submit_button.enabled = True
+
+    def _get_journal(self, path: Path) -> Journal:
+        """Get the journal object form `path`, if the journal was opened before, get the changed object and parse it."""
+        try:
+            journal = self._journals[path]
+        except KeyError:
+            journal = self._journals[path] = Journal(path)
+        journal.parse()
+        return journal
 
     def emit_and_close(
         self, journal: Journal, route: RouteList, route_index: int

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -267,7 +267,6 @@ class NewRouteWindow(NewRouteWindowGUI):
         self.spansh_neutron_tab.submit_button.enabled = bool(
             self.spansh_neutron_tab.source_edit.text
             and self.spansh_neutron_tab.target_edit.text
-            and not self.selected_journal.shut_down
         )
 
     def _set_exact_submit(self) -> None:
@@ -275,7 +274,6 @@ class NewRouteWindow(NewRouteWindowGUI):
         self.spansh_exact_tab.submit_button.enabled = bool(
             self.spansh_exact_tab.source_edit.text
             and self.spansh_exact_tab.target_edit.text
-            and not self.selected_journal.shut_down
             and (
                 self.selected_journal.ship is not None
                 or self.spansh_exact_tab.use_clipboard_checkbox.checked

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -461,7 +461,7 @@ class NewRouteWindow(NewRouteWindowGUI):
     def _change_journal(self, index: int) -> None:
         """Change the current journal and update the UI with its data, or display an error if shut down."""
         journal = self._journals[index]
-        log.info(f"Changing selected journal to index {index} ({journal.path}).")
+        log.info(f"Changing selected journal to index {index} ({journal.path.name}).")
 
         self.selected_journal = journal
         self.selected_journal.shut_down_sig.connect(self._set_neutron_submit)

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -125,6 +125,8 @@ class NewRouteWindow(NewRouteWindowGUI):
     def _submit_neutron(self) -> None:
         """Submit a neutron plotter request to spansh."""
         log.info("Submitting neutron job.")
+        self._abort_request()
+
         self._current_network_reply = SpanshReplyTracker(self)
         self._current_network_reply.make_request(
             SPANSH_API_URL + "/route",
@@ -149,6 +151,8 @@ class NewRouteWindow(NewRouteWindowGUI):
     def _submit_exact(self) -> None:
         """Submit an exact plotter request to spansh."""
         log.info("Submitting exact job.")
+        self._abort_request()
+
         if self.spansh_exact_tab.use_clipboard_checkbox.checked:
             try:
                 ship = Ship.from_coriolis(
@@ -583,6 +587,10 @@ class NewRouteWindow(NewRouteWindowGUI):
         """Retranslate the GUI when a language change occurs."""
         if event.type() == QtCore.QEvent.LanguageChange:
             self.retranslate()
+
+    def close_event(self, event: QtGui.QCloseEvent) -> None:
+        """Abort any running network request on close."""
+        self._abort_request()
 
     def retranslate(self) -> None:
         """Retranslate text that is always on display."""

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -251,7 +251,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         """Recalculate jump range with the new cargo_mass."""
         if cargo_mass is None:
             cargo_mass = self.selected_journal.cargo
-        if self.selected_journal.ship.initialized:  # Ship may not be available yet
+        if self.selected_journal.ship is not None:  # Ship may not be available yet
             self.spansh_neutron_tab.range_spin.value = (
                 self.selected_journal.ship.jump_range(cargo_mass=cargo_mass)
             )
@@ -271,7 +271,7 @@ class NewRouteWindow(NewRouteWindowGUI):
             and self.spansh_exact_tab.target_edit.text
             and not self.selected_journal.shut_down
             and (
-                self.selected_journal.ship.initialized
+                self.selected_journal.ship is not None
                 or self.spansh_exact_tab.use_clipboard_checkbox.checked
             )
         )
@@ -461,7 +461,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         self._journal_worker.start()
 
         if (
-            journal.ship.initialized
+            journal.ship is not None
             and journal.location is not None
             and journal.cargo is not None
         ):

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -120,6 +120,14 @@ class NewRouteWindow(NewRouteWindowGUI):
         for signal in self.combo_signals:
             signal.connect()
 
+        for button in (
+            self.csv_tab.refresh_button,
+            self.spansh_neutron_tab.refresh_button,
+            self.spansh_exact_tab.refresh_button,
+            self.last_route_tab.refresh_button,
+        ):
+            button.pressed.connect(self._populate_journal_combos)
+
         self.tab_widget.currentChanged.connect(self._display_saved_route)
         self._route_displayed = False
         self._loaded_route: list[NeutronPlotRow] | None = None

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -461,6 +461,13 @@ class NewRouteWindow(NewRouteWindowGUI):
         journal = self._journals[index]
         log.info(f"Changing selected journal to index {index} ({journal.path.name}).")
 
+        journal.parse()
+        if journal.shut_down:
+            if self._journal_worker is not None:
+                self._journal_worker.stop()
+            self._refresh_journals_on_shutdown()
+            return
+
         self.selected_journal = journal
 
         self.selected_journal.shut_down_sig.connect(self._refresh_journals_on_shutdown)

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -127,6 +127,7 @@ class NewRouteWindow(NewRouteWindowGUI):
             self.last_route_tab.refresh_button,
         ):
             button.pressed.connect(self._populate_journal_combos)
+            button.pressed.connect(partial(self._change_journal, 0))
 
         self.tab_widget.currentChanged.connect(self._display_saved_route)
         self._route_displayed = False

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -288,7 +288,7 @@ class NewRouteWindow(NewRouteWindowGUI):
     def _display_nearest_window(self) -> None:
         """Display the nearest system finder window and link its signals."""
         log.info("Displaying nearest window.")
-        window = NearestWindow(self, self.selected_journal.location, self.status_bar)
+        window = NearestWindow(self, self.selected_journal.location, self.status_widget)
         window.copy_to_source_button.pressed.connect(
             partial(
                 self._set_line_edits_from_nearest,

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -434,12 +434,18 @@ class NewRouteWindow(NewRouteWindowGUI):
                 )
             )
 
-        with contextlib.ExitStack() as exit_stack:
-            for signal in self.combo_signals:
-                exit_stack.enter_context(signal.temporarily_disconnect())
-            for combo_box in self._combo_boxes:
-                combo_box.clear()
-                combo_box.add_items(combo_items)
+        if self._journals:
+            with contextlib.ExitStack() as exit_stack:
+                for signal in self.combo_signals:
+                    exit_stack.enter_context(signal.temporarily_disconnect())
+                for combo_box in self._combo_boxes:
+                    combo_box.clear()
+                    combo_box.add_items(combo_items)
+        else:
+            self._show_status_message(
+                _("Found no active journal files from within the last week."),
+                timeout=10_000,
+            )
 
     def _change_journal(self, index: int) -> None:
         """Change the current journal and update the UI with its data, or display an error if shut down."""

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -440,21 +440,28 @@ class NewRouteWindow(NewRouteWindowGUI):
                 )
             )
 
-        if self._journals:
-            log.info(f"Populating journal combos with {len(self._journals)} journals.")
-            with contextlib.ExitStack() as exit_stack:
-                for signal in self.combo_signals:
-                    exit_stack.enter_context(signal.temporarily_disconnect())
+        with contextlib.ExitStack() as exit_stack:
+            for signal in self.combo_signals:
+                exit_stack.enter_context(signal.temporarily_disconnect())
+
+            if self._journals:
+                log.info(
+                    f"Populating journal combos with {len(self._journals)} journals."
+                )
                 for combo_box in self._combo_boxes:
                     combo_box.clear()
                     combo_box.add_items(combo_items)
-            self._change_journal(0, show_change_message=show_change_message)
-        else:
-            log.info("No valid journals found to populate combos with.")
-            self._show_status_message(
-                _("Found no active journal files from within the last week."),
-                timeout=10_000,
-            )
+                self._change_journal(0, show_change_message=show_change_message)
+
+            else:
+                for combo_box in self._combo_boxes:
+                    combo_box.clear()
+
+                log.info("No valid journals found to populate combos with.")
+                self._show_status_message(
+                    _("Found no active journal files from within the last week."),
+                    timeout=10_000,
+                )
 
     def _change_journal(self, index: int, *, show_change_message: bool = True) -> None:
         """Change the current journal and update the UI with its data, or display an error if shut down."""

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import contextlib
 import csv
+import datetime
 import json
 import logging
 import typing as t
 from functools import partial
 from pathlib import Path
 
+import babel.dates
 from PySide6 import QtCore, QtGui, QtWidgets
 
 # noinspection PyUnresolvedReferences
@@ -18,6 +20,7 @@ from __feature__ import snake_case, true_property  # noqa F401
 from auto_neutron import settings
 from auto_neutron.constants import ROUTE_FILE_NAME, SPANSH_API_URL, get_config_dir
 from auto_neutron.journal import Journal, get_unique_cmdr_journals
+from auto_neutron.locale import get_active_locale
 from auto_neutron.route_plots import (
     ExactPlotRow,
     NeutronPlotRow,
@@ -462,7 +465,18 @@ class NewRouteWindow(NewRouteWindowGUI):
         ):
             self._set_widget_values()
 
-        self.status_widget.text = ""
+        creation_time = datetime.datetime.fromtimestamp(journal.path.stat().st_ctime)
+        formatted_time = babel.dates.format_time(
+            creation_time, locale=get_active_locale()
+        )
+
+        self._show_status_message(
+            _("Selected journal using {}, created at {}").format(
+                "Oddysey" if journal.is_oddysey else "Horizons", formatted_time
+            ),
+            timeout=5_000,
+        )
+
         self.csv_tab.submit_button.enabled = True
         self._set_neutron_submit()
         self._set_exact_submit()

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -57,12 +57,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         self._status_has_hover = False
         self._status_scheduled_reset = False
         self._setup_status_widget()
-        self._combo_boxes = (
-            self.csv_tab.journal_combo,
-            self.spansh_neutron_tab.journal_combo,
-            self.spansh_exact_tab.journal_combo,
-            self.last_route_tab.journal_combo,
-        )
+        self._combo_boxes = [tab.journal_combo for tab in self.tabs]
 
         # region spansh tabs init
         self.spansh_neutron_tab.nearest_button.pressed.connect(
@@ -120,13 +115,8 @@ class NewRouteWindow(NewRouteWindowGUI):
         for signal in self.combo_signals:
             signal.connect()
 
-        for button in (
-            self.csv_tab.refresh_button,
-            self.spansh_neutron_tab.refresh_button,
-            self.spansh_exact_tab.refresh_button,
-            self.last_route_tab.refresh_button,
-        ):
-            button.pressed.connect(self._populate_journal_combos)
+        for tab in self.tabs:
+            tab.refresh_button.pressed.connect(self._populate_journal_combos)
 
         self.tab_widget.currentChanged.connect(self._display_saved_route)
         self._route_displayed = False

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -442,17 +442,6 @@ class NewRouteWindow(NewRouteWindowGUI):
         log.info(f"Changing selected journal to {journal.path}.")
 
         self.selected_journal = journal
-        if journal.shut_down:
-            self._show_status_message(
-                _("Selected journal ended with a shut down event."), 10_000
-            )
-            self.csv_tab.submit_button.enabled = False
-            self._set_neutron_submit()
-            self._set_exact_submit()
-            self.last_route_tab.submit_button.enabled = False
-            self._journal_worker = None
-            return
-
         self.selected_journal.shut_down_sig.connect(self._set_neutron_submit)
         self.selected_journal.shut_down_sig.connect(self._set_exact_submit)
 

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -238,21 +238,24 @@ class NewRouteWindow(NewRouteWindowGUI):
         self.spansh_neutron_tab.cargo_slider.maximum = (
             self.selected_journal.ship.max_cargo
         )
-        self.spansh_neutron_tab.cargo_slider.value = self.selected_journal.cargo
+        if self.selected_journal.cargo is not None:
+            self.spansh_neutron_tab.cargo_slider.value = self.selected_journal.cargo
+            self.spansh_exact_tab.cargo_slider.value = self.selected_journal.cargo
 
-        self.spansh_exact_tab.cargo_slider.value = self.selected_journal.cargo
-
-        self.spansh_neutron_tab.range_spin.value = (
-            self.selected_journal.ship.jump_range(
-                cargo_mass=self.selected_journal.cargo
+            self.spansh_neutron_tab.range_spin.value = (
+                self.selected_journal.ship.jump_range(
+                    cargo_mass=self.selected_journal.cargo
+                )
             )
-        )
 
     def _recalculate_range(self, cargo_mass: int | None = None) -> None:
         """Recalculate jump range with the new cargo_mass."""
         if cargo_mass is None:
             cargo_mass = self.selected_journal.cargo
-        if self.selected_journal.ship is not None:  # Ship may not be available yet
+        if (
+            self.selected_journal.ship is not None
+            and self.selected_journal.cargo is not None
+        ):  # Ship may not be available yet
             self.spansh_neutron_tab.range_spin.value = (
                 self.selected_journal.ship.jump_range(cargo_mass=cargo_mass)
             )

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -444,6 +444,7 @@ class NewRouteWindow(NewRouteWindowGUI):
             )
 
         if self._journals:
+            log.info(f"Populating journal combos with {len(self._journals)} journals.")
             with contextlib.ExitStack() as exit_stack:
                 for signal in self.combo_signals:
                     exit_stack.enter_context(signal.temporarily_disconnect())
@@ -451,6 +452,7 @@ class NewRouteWindow(NewRouteWindowGUI):
                     combo_box.clear()
                     combo_box.add_items(combo_items)
         else:
+            log.info("No valid journals found to populate combos with.")
             self._show_status_message(
                 _("Found no active journal files from within the last week."),
                 timeout=10_000,
@@ -459,7 +461,7 @@ class NewRouteWindow(NewRouteWindowGUI):
     def _change_journal(self, index: int) -> None:
         """Change the current journal and update the UI with its data, or display an error if shut down."""
         journal = self._journals[index]
-        log.info(f"Changing selected journal to {journal.path}.")
+        log.info(f"Changing selected journal to index {index} ({journal.path}).")
 
         self.selected_journal = journal
         self.selected_journal.shut_down_sig.connect(self._set_neutron_submit)

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -59,6 +59,12 @@ class NewRouteWindow(NewRouteWindowGUI):
         self._status_has_hover = False
         self._status_scheduled_reset = False
         self._setup_status_widget()
+        self._combo_boxes = (
+            self.csv_tab.journal_combo,
+            self.spansh_neutron_tab.journal_combo,
+            self.spansh_exact_tab.journal_combo,
+            self.last_route_tab.journal_combo,
+        )
 
         # region spansh tabs init
         self.spansh_neutron_tab.nearest_button.pressed.connect(
@@ -105,24 +111,14 @@ class NewRouteWindow(NewRouteWindowGUI):
 
         self.last_route_tab.submit_button.pressed.connect(self._last_route_submit)
 
-        self.combo_signals = (
+        self.combo_signals = [
             ReconnectingSignal(
-                self.csv_tab.journal_combo.currentIndexChanged,
+                combo_box.currentIndexChanged,
                 self._sync_journal_combos,
-            ),
-            ReconnectingSignal(
-                self.spansh_neutron_tab.journal_combo.currentIndexChanged,
-                self._sync_journal_combos,
-            ),
-            ReconnectingSignal(
-                self.spansh_exact_tab.journal_combo.currentIndexChanged,
-                self._sync_journal_combos,
-            ),
-            ReconnectingSignal(
-                self.last_route_tab.journal_combo.currentIndexChanged,
-                self._sync_journal_combos,
-            ),
-        )
+            )
+            for combo_box in self._combo_boxes
+        ]
+
         for signal in self.combo_signals:
             signal.connect()
 
@@ -415,10 +411,8 @@ class NewRouteWindow(NewRouteWindowGUI):
         with exit_stack:
             for signal in self.combo_signals:
                 exit_stack.enter_context(signal.temporarily_disconnect())
-            self.csv_tab.journal_combo.current_index = index
-            self.spansh_neutron_tab.journal_combo.current_index = index
-            self.spansh_exact_tab.journal_combo.current_index = index
-            self.last_route_tab.journal_combo.current_index = index
+            for combo_box in self._combo_boxes:
+                combo_box.index = index
         self._change_journal(index)
 
     def _change_journal(self, index: int) -> None:

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -22,7 +22,7 @@ from auto_neutron.constants import (
     SPANSH_API_URL,
     get_config_dir,
 )
-from auto_neutron.journal import Journal
+from auto_neutron.journal import Journal, get_cached_journal
 from auto_neutron.route_plots import (
     ExactPlotRow,
     NeutronPlotRow,
@@ -430,7 +430,7 @@ class NewRouteWindow(NewRouteWindowGUI):
         )
         journal_path = journals[min(index, len(journals) - 1)]
         log.info(f"Changing selected journal to {journal_path}.")
-        journal = self._get_journal(journal_path)
+        journal = get_cached_journal(journal_path)
 
         self.selected_journal = journal
         if journal.shut_down:
@@ -469,15 +469,6 @@ class NewRouteWindow(NewRouteWindowGUI):
         self._set_neutron_submit()
         self._set_exact_submit()
         self.last_route_tab.submit_button.enabled = True
-
-    def _get_journal(self, path: Path) -> Journal:
-        """Get the journal object form `path`, if the journal was opened before, get the changed object and parse it."""
-        try:
-            journal = self._journals[path]
-        except KeyError:
-            journal = self._journals[path] = Journal(path)
-        journal.parse()
-        return journal
 
     def emit_and_close(
         self, journal: Journal, route: RouteList, route_index: int

--- a/auto_neutron/windows/new_route_window.py
+++ b/auto_neutron/windows/new_route_window.py
@@ -462,9 +462,8 @@ class NewRouteWindow(NewRouteWindowGUI):
         log.info(f"Changing selected journal to index {index} ({journal.path.name}).")
 
         self.selected_journal = journal
-        self.selected_journal.shut_down_sig.connect(self._set_neutron_submit)
-        self.selected_journal.shut_down_sig.connect(self._set_exact_submit)
 
+        self.selected_journal.shut_down_sig.connect(self._populate_journal_combos)
         self.selected_journal.loadout_sig.connect(lambda: self._recalculate_range())
         self.selected_journal.loadout_sig.connect(self._set_widget_values)
         self.selected_journal.system_sig.connect(self._set_widget_values)

--- a/auto_neutron/windows/settings_window.py
+++ b/auto_neutron/windows/settings_window.py
@@ -15,7 +15,8 @@ from auto_neutron import settings
 from auto_neutron.constants import AHK_PATH
 from auto_neutron.locale import code_from_locale, get_available_locales
 from auto_neutron.settings import delay_sync
-from auto_neutron.windows.gui.settings_window import SettingsWindowGUI
+
+from .gui.settings_window import SettingsWindowGUI
 
 log = logging.getLogger(__name__)
 

--- a/auto_neutron/windows/update_error_window.py
+++ b/auto_neutron/windows/update_error_window.py
@@ -7,7 +7,8 @@ from PySide6 import QtCore, QtWidgets
 
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property  # noqa: F401
-from auto_neutron.windows.gui.update_error_window import UpdateErrorWindowGUI
+
+from .gui.update_error_window import UpdateErrorWindowGUI
 
 
 class UpdateErrorWindow(UpdateErrorWindowGUI):

--- a/auto_neutron/workers.py
+++ b/auto_neutron/workers.py
@@ -71,7 +71,7 @@ class GameWorker(_WorkerBase):
     def __init__(self, parent: QtCore.QObject, route: RouteList, journal: Journal):
         super().__init__(parent, journal.tail(), 500)
         self.route = route
-        journal.system_sig.connect(self.emit_next_system)
+        self._journal_connection = journal.system_sig.connect(self.emit_next_system)
 
     def emit_next_system(self, location: Location) -> None:
         """Emit the next system in the route and its index if location is in the route, or the end of route signal."""
@@ -81,6 +81,11 @@ class GameWorker(_WorkerBase):
                 self.new_system_index_sig.emit(new_index)
             else:
                 self.route_end_sig.emit(new_index)
+
+    def stop(self) -> None:
+        """Disconnect the journal system signal."""
+        super().stop()
+        self.disconnect(self._journal_connection)
 
 
 class StatusWorker(_WorkerBase):

--- a/auto_neutron/workers.py
+++ b/auto_neutron/workers.py
@@ -26,21 +26,50 @@ if t.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class GameWorker(QtCore.QObject):
+class _WorkerBase(QtCore.QObject):
+    """The base class used for workers that advance generators at a given interval."""
+
+    def __init__(
+        self,
+        parent: QtCore.QObject,
+        generator: collections.abc.Generator,
+        interval: int,
+    ):
+        super().__init__(parent)
+        self._generator = generator
+        self._timer = QtCore.QTimer(self)
+        self._timer.interval = interval
+        self._advance_connection = self._timer.timeout.connect(
+            partial(next, self._generator)
+        )
+        self._stopped = False
+
+    def start(self) -> None:
+        """Start the worker to tail the journal file."""
+        log.debug("Starting GameWorker.")
+        if self._stopped:
+            raise RuntimeError("Can't restart a stopped worker.")
+        self._timer.start()
+
+    def stop(self) -> None:
+        """Stop the worker from tailing the journal file."""
+        log.debug(f"Stopping {self.__class__.__name__}.")
+        # Remove the generator advance signal, connect it to close the generator,
+        # and set single_shot_ so the next timeout is the last.
+        self._timer.timeout.connect(self._generator.close)
+        self._timer.disconnect(self._advance_connection)
+        self._timer.single_shot_ = True
+        self._stopped = True
+
+
+class GameWorker(_WorkerBase):
     """Handle dispatching route signals from the journal's tailer."""
 
     new_system_index_sig = QtCore.Signal(int)
     route_end_sig = QtCore.Signal(int)
 
     def __init__(self, parent: QtCore.QObject, route: RouteList, journal: Journal):
-        super().__init__(parent)
-        self._generator = journal.tail()
-        self._timer = QtCore.QTimer(self)
-        self._timer.interval = 250
-        self._advance_connection = self._timer.timeout.connect(
-            partial(next, self._generator)
-        )
-        self._stopped = False
+        super().__init__(parent, journal.tail(), 500)
         self.route = route
         journal.system_sig.connect(self.emit_next_system)
 
@@ -53,51 +82,14 @@ class GameWorker(QtCore.QObject):
             else:
                 self.route_end_sig.emit(new_index)
 
-    def start(self) -> None:
-        """Start the worker to tail the journal file."""
-        log.debug("Starting GameWorker.")
-        if self._stopped:
-            raise RuntimeError("Can't restart a stopped worker.")
-        self._timer.start()
 
-    def stop(self) -> None:
-        """Stop the worker from tailing the journal file."""
-        log.debug("Stopping GameWorker.")
-        self._timer.timeout.connect(self._generator.close)
-        self._timer.disconnect(self._advance_connection)
-        self._timer.single_shot_ = True
-        self._stopped = True
-
-
-class StatusWorker(QtCore.QObject):
+class StatusWorker(_WorkerBase):
     """Follow the status file and dispatch `status_signal` from its contents."""
 
     status_signal = QtCore.Signal(dict)
 
     def __init__(self, parent: QtCore.QObject):
-        super().__init__(parent)
-        self._generator = self.read_status()
-        self._timer = QtCore.QTimer(self)
-        self._advance_connection = self._timer.timeout.connect(
-            partial(next, self._generator)
-        )
-        self._timer.interval = 250
-        self._stopped = False
-
-    def start(self) -> None:
-        """Start the worker to follow the status file."""
-        log.debug("Starting StatusWorker.")
-        if self._stopped:
-            raise RuntimeError("Can't restart a stopped worker.")
-        self._timer.start()
-
-    def stop(self) -> None:
-        """Stop following the status file."""
-        log.debug("Stopping StatusWorker.")
-        self._timer.timeout.connect(self._generator.close)
-        self._timer.disconnect(self._advance_connection)
-        self._timer.single_shot_ = True
-        self._stopped = True
+        super().__init__(parent, self.read_status(), 250)
 
     def read_status(self) -> collections.abc.Generator[None, None, None]:
         """Emit status_signal with the status dict on every status file change."""

--- a/auto_neutron/workers.py
+++ b/auto_neutron/workers.py
@@ -77,14 +77,13 @@ class StatusWorker(QtCore.QObject):
         self._timer = QtCore.QTimer(self)
         self._timer.timeout.connect(partial(next, self._generator))
         self._timer.interval = 250
-        self._running = False
+        self._stopped = False
 
     def start(self) -> None:
         """Start the worker to follow the status file."""
         log.debug("Starting StatusWorker.")
-        if self._running:
-            raise RuntimeError("Worker already started")
-        self._running = True
+        if self._stopped:
+            raise RuntimeError("Can't restart a stopped worker.")
         self._timer.start()
 
     def stop(self) -> None:
@@ -92,7 +91,7 @@ class StatusWorker(QtCore.QObject):
         log.debug("Stopping StatusWorker.")
         self._timer.stop()
         self._generator.close()
-        self._running = False
+        self._stopped = True
 
     def read_status(self) -> collections.abc.Generator[None, None, None]:
         """Emit status_signal with the status dict on every status file change."""

--- a/locale/auto_neutron.pot
+++ b/locale/auto_neutron.pot
@@ -5,9 +5,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Auto Neutron 2.0.8\n"
+"Project-Id-Version: Auto Neutron 2.1.0\n"
 "Report-Msgid-Bugs-To: Numerlor@gmail\n"
-"POT-Creation-Date: 2022-02-13 22:41+0100\n"
+"POT-Creation-Date: 2022-02-24 22:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,47 +16,51 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: auto_neutron/route_plots.py:275
-msgid "Received invalid response from Spansh."
-msgstr ""
-
-#: auto_neutron/route_plots.py:278 auto_neutron/windows/nearest_window.py:72
+#: auto_neutron/route_plots.py:299 auto_neutron/windows/nearest_window.py:85
 msgid "Received error from Spansh: {}"
 msgstr ""
 
-#: auto_neutron/self_updater.py:110
+#: auto_neutron/route_plots.py:331
+msgid "Received invalid response from Spansh."
+msgstr ""
+
+#: auto_neutron/self_updater.py:109
 msgid "Downloading new release"
 msgstr ""
 
-#: auto_neutron/self_updater.py:149
+#: auto_neutron/self_updater.py:148
 msgid "Unable to find appropriate new release."
 msgstr ""
 
-#: auto_neutron/self_updater.py:220
+#: auto_neutron/self_updater.py:219
 msgid "Downloaded file does not match expected checksum."
 msgstr ""
 
-#: auto_neutron/self_updater.py:229
+#: auto_neutron/self_updater.py:228
 msgid "Unable to rename executable: "
 msgstr ""
 
-#: auto_neutron/self_updater.py:234
+#: auto_neutron/self_updater.py:233
 msgid "Unable to create new executable: "
 msgstr ""
 
-#: auto_neutron/self_updater.py:245
+#: auto_neutron/self_updater.py:244
 msgid "Unable to create temporary directory: "
 msgstr ""
 
-#: auto_neutron/self_updater.py:254
+#: auto_neutron/self_updater.py:253
 msgid "Unable to move files into temporary directory: "
 msgstr ""
 
-#: auto_neutron/self_updater.py:262
+#: auto_neutron/self_updater.py:261
 msgid "Unable to extract new release files: "
 msgstr ""
 
-#: auto_neutron/windows/download_confirm_dialog.py:45
+#: auto_neutron/utils/utils.py:119
+msgid "<Main menu>"
+msgstr ""
+
+#: auto_neutron/windows/download_confirm_dialog.py:44
 msgid "A new release is available: {} -> {}"
 msgstr ""
 
@@ -65,7 +69,7 @@ msgstr ""
 msgid "Multiple unexpected errors have occurred (x{})"
 msgstr ""
 
-#: auto_neutron/windows/license_window.py:47
+#: auto_neutron/windows/license_window.py:56
 msgid ""
 "        Auto_Neutron Copyright (C) 2019 Numerlor\\\n"
 "        This program comes with ABSOLUTELY NO WARRANTY.\\\n"
@@ -84,30 +88,37 @@ msgid ""
 "        {python_copyright_notice}\n"
 "          Python is licensed under the {psf_license_agreement_hyperlink},"
 " see {python_licenses_hyperlink} for more details\n"
+"\n"
+"        And The Breeze Icons Theme Copyright (C) 2014 Uri Herrera "
+"<uri_herrera@nitrux.in> and others, under the {lgplv3_hyperlink}.\n"
 "        "
 msgstr ""
 
-#: auto_neutron/windows/license_window.py:66
+#: auto_neutron/windows/license_window.py:77
 msgid "GPLv3 license"
 msgstr ""
 
-#: auto_neutron/windows/license_window.py:68
+#: auto_neutron/windows/license_window.py:79
+msgid "LGPLv3 license"
+msgstr ""
+
+#: auto_neutron/windows/license_window.py:82
 msgid "gnu.org/licenses"
 msgstr ""
 
-#: auto_neutron/windows/license_window.py:71
+#: auto_neutron/windows/license_window.py:85
 msgid "PSF License Agreement"
 msgstr ""
 
-#: auto_neutron/windows/license_window.py:74
+#: auto_neutron/windows/license_window.py:88
 msgid "docs.python.org/license.html"
 msgstr ""
 
-#: auto_neutron/windows/license_window.py:76
+#: auto_neutron/windows/license_window.py:90
 msgid "MIT license"
 msgstr ""
 
-#: auto_neutron/windows/license_window.py:78
+#: auto_neutron/windows/license_window.py:92
 msgid "3-Clause BSD license"
 msgstr ""
 
@@ -133,57 +144,65 @@ msgstr ""
 msgid "Jumps"
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:168
+#: auto_neutron/windows/new_route_window.py:163
 msgid "Invalid ship data in clipboard."
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:336
+#: auto_neutron/windows/new_route_window.py:357
 msgid "Select CSV file"
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:336
+#: auto_neutron/windows/new_route_window.py:357
 msgid "CSV (*.csv);;All types (*.*)"
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:365
+#: auto_neutron/windows/new_route_window.py:386
 msgid "Invalid CSV file."
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:370
+#: auto_neutron/windows/new_route_window.py:391
 msgid "CSV file doesn't exist."
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:372
+#: auto_neutron/windows/new_route_window.py:393
 msgid "Invalid CSV file: "
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:374
+#: auto_neutron/windows/new_route_window.py:395
 msgid "Truncated data in CSV file."
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:376
+#: auto_neutron/windows/new_route_window.py:397
 msgid "Invalid data in CSV file."
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:378
+#: auto_neutron/windows/new_route_window.py:399
 msgid "Invalid path."
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:439
-msgid "Selected journal ended with a shut down event."
+#: auto_neutron/windows/new_route_window.py:477
+msgid "Found no active journal files from within the last week."
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:521
+msgid "Selected journal using {}, created at {}"
+msgstr ""
+
+#: auto_neutron/windows/new_route_window.py:555
+msgid "Selected journal got shut down, available journals refreshed."
 msgstr ""
 
 #. NOTE: Source system
-#: auto_neutron/windows/new_route_window.py:540
+#: auto_neutron/windows/new_route_window.py:635
 msgid "Source: {}"
 msgstr ""
 
-#: auto_neutron/windows/new_route_window.py:543
+#: auto_neutron/windows/new_route_window.py:638
 msgid "Saved location: {}"
 msgstr ""
 
 #. NOTE: destination system
-#: auto_neutron/windows/new_route_window.py:547
+#: auto_neutron/windows/new_route_window.py:642
 msgid "Destination: {}"
 msgstr ""
 
@@ -226,51 +245,51 @@ msgid "Quit"
 msgstr ""
 
 #: auto_neutron/windows/gui/error_window.py:49
-#: auto_neutron/windows/gui/main_window.py:136
+#: auto_neutron/windows/gui/main_window.py:133
 #: auto_neutron/windows/gui/shut_down_window.py:72
 msgid "Save route"
 msgstr ""
 
-#: auto_neutron/windows/gui/license_window.py:54
+#: auto_neutron/windows/gui/license_window.py:52
 msgid "About Qt"
 msgstr ""
 
-#: auto_neutron/windows/gui/license_window.py:55
+#: auto_neutron/windows/gui/license_window.py:53
 msgid "Back"
 msgstr ""
 
-#: auto_neutron/windows/gui/main_window.py:135
+#: auto_neutron/windows/gui/main_window.py:132
 msgid "Edit"
 msgstr ""
 
-#: auto_neutron/windows/gui/main_window.py:137
+#: auto_neutron/windows/gui/main_window.py:134
 msgid "Copy"
 msgstr ""
 
-#: auto_neutron/windows/gui/main_window.py:138
+#: auto_neutron/windows/gui/main_window.py:135
 msgid "Start a new route"
 msgstr ""
 
-#: auto_neutron/windows/gui/main_window.py:139
-#: auto_neutron/windows/gui/settings_window.py:344
+#: auto_neutron/windows/gui/main_window.py:136
+#: auto_neutron/windows/gui/settings_window.py:343
 msgid "Settings"
 msgstr ""
 
-#: auto_neutron/windows/gui/main_window.py:140
+#: auto_neutron/windows/gui/main_window.py:137
 msgid "About"
 msgstr ""
 
-#: auto_neutron/windows/gui/main_window.py:145
+#: auto_neutron/windows/gui/main_window.py:142
 #: auto_neutron/windows/gui/nearest_window.py:131
 msgid "System name"
 msgstr ""
 
-#: auto_neutron/windows/gui/main_window.py:147
+#: auto_neutron/windows/gui/main_window.py:144
 #: auto_neutron/windows/gui/nearest_window.py:132
 msgid "Distance"
 msgstr ""
 
-#: auto_neutron/windows/gui/main_window.py:149
+#: auto_neutron/windows/gui/main_window.py:146
 msgid "Remaining"
 msgstr ""
 
@@ -329,193 +348,194 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:90
+#: auto_neutron/windows/gui/new_route_window.py:129
 msgid "Source system"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:91
+#: auto_neutron/windows/gui/new_route_window.py:130
 msgid "Destination system"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:93
+#: auto_neutron/windows/gui/new_route_window.py:132
 msgid "Cargo"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:95
+#: auto_neutron/windows/gui/new_route_window.py:134
 msgid "Submit"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:97
-#: auto_neutron/windows/gui/shut_down_window.py:75
-msgid "Last journal"
+#: auto_neutron/windows/gui/new_route_window.py:135
+msgid "Abort"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:97
-#: auto_neutron/windows/gui/shut_down_window.py:75
-msgid "Second to last"
+#: auto_neutron/windows/gui/new_route_window.py:136
+msgid "Cancel the current route plot"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:97
-#: auto_neutron/windows/gui/shut_down_window.py:75
-msgid "Third to last"
+#: auto_neutron/windows/gui/new_route_window.py:137
+msgid "Refresh journals"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:154
+#: auto_neutron/windows/gui/new_route_window.py:189
 msgid "Range"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:155
+#: auto_neutron/windows/gui/new_route_window.py:190
 msgid "Efficiency"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:156
-#: auto_neutron/windows/gui/new_route_window.py:206
+#: auto_neutron/windows/gui/new_route_window.py:191
+#: auto_neutron/windows/gui/new_route_window.py:241
 msgid "Nearest"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:201
+#: auto_neutron/windows/gui/new_route_window.py:236
 msgid "Already supercharged"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:202
+#: auto_neutron/windows/gui/new_route_window.py:237
 msgid "Use supercharge"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:203
+#: auto_neutron/windows/gui/new_route_window.py:238
 msgid "Use FSD injections"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:204
+#: auto_neutron/windows/gui/new_route_window.py:239
 msgid "Exclude secondary stars"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:205
+#: auto_neutron/windows/gui/new_route_window.py:240
 msgid "Use ship from clipboard"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:309
-msgid "CSV"
+#: auto_neutron/windows/gui/new_route_window.py:271
+msgid "CSV path"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:310
+#: auto_neutron/windows/gui/new_route_window.py:359
 msgid "Neutron plotter"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:311
+#: auto_neutron/windows/gui/new_route_window.py:360
 msgid "Galaxy plotter"
 msgstr ""
 
-#: auto_neutron/windows/gui/new_route_window.py:312
+#: auto_neutron/windows/gui/new_route_window.py:361
+msgid "CSV"
+msgstr ""
+
+#: auto_neutron/windows/gui/new_route_window.py:362
 msgid "Saved route"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:66
+#: auto_neutron/windows/gui/settings_window.py:65
 msgid "Bold"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:67
+#: auto_neutron/windows/gui/settings_window.py:66
 msgid "Language"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:68
+#: auto_neutron/windows/gui/settings_window.py:67
 msgid "Dark mode"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:95
+#: auto_neutron/windows/gui/settings_window.py:94
 msgid "Save route on window close"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:96
+#: auto_neutron/windows/gui/settings_window.py:95
 msgid "Copy Mode"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:97
+#: auto_neutron/windows/gui/settings_window.py:96
 msgid "AHK Path"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:98
+#: auto_neutron/windows/gui/settings_window.py:97
 msgid "Auto scroll"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:148
+#: auto_neutron/windows/gui/settings_window.py:147
 msgid "Taskbar fuel alert"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:149
+#: auto_neutron/windows/gui/settings_window.py:148
 msgid "Sound fuel alert"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:150
+#: auto_neutron/windows/gui/settings_window.py:149
 msgid "Custom sound alert file:"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:152
+#: auto_neutron/windows/gui/settings_window.py:151
 #, python-format
 msgid "%% of maximum fuel usage left in tank before triggering alert"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:204
+#: auto_neutron/windows/gui/settings_window.py:203
 msgid "Galaxy map open key"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:205
+#: auto_neutron/windows/gui/settings_window.py:204
 msgid "Time to wait for galaxy map to open"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:206
+#: auto_neutron/windows/gui/settings_window.py:205
 msgid "Key to use to navigate right in the map"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:209
+#: auto_neutron/windows/gui/settings_window.py:208
 msgid "Key to use to focus onto the system input field"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:212
+#: auto_neutron/windows/gui/settings_window.py:211
 msgid "Key to submit the entered system"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:215
+#: auto_neutron/windows/gui/settings_window.py:214
 msgid "AutoHotKey key reference"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:260
+#: auto_neutron/windows/gui/settings_window.py:259
 msgid ""
 "Bind to trigger the script, # for win key, ! for alt, ^ for control, + "
 "for shift"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:263
+#: auto_neutron/windows/gui/settings_window.py:262
 msgid "Simple mode"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:264
+#: auto_neutron/windows/gui/settings_window.py:263
 msgid ""
 "With Simple mode enabled, a default script filled with the specified "
 "settings is used, if simple mode is not enabled, the script can be fully "
 "customized."
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:333
+#: auto_neutron/windows/gui/settings_window.py:332
 msgid "Ok"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:334
+#: auto_neutron/windows/gui/settings_window.py:333
 msgid "Apply"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:338
+#: auto_neutron/windows/gui/settings_window.py:337
 msgid "Appearance"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:338
+#: auto_neutron/windows/gui/settings_window.py:337
 msgid "Behaviour"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:338
+#: auto_neutron/windows/gui/settings_window.py:337
 msgid "Alerts"
 msgstr ""
 
-#: auto_neutron/windows/gui/settings_window.py:338
+#: auto_neutron/windows/gui/settings_window.py:337
 msgid "AHK script"
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/auto_neutron.po
+++ b/locale/en/LC_MESSAGES/auto_neutron.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Auto Neutron 2.0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/Numerlor/Auto_Neutron/issues\n"
-"POT-Creation-Date: 2022-02-13 22:41+0100\n"
+"POT-Creation-Date: 2022-02-24 22:12+0100\n"
 "PO-Revision-Date: 2022-01-02 23:58+0100\n"
 "Last-Translator: Numerlor <Numerlor@gmail.com>\n"
 "Language: en\n"
@@ -18,47 +18,51 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: auto_neutron/route_plots.py:275
-msgid "Received invalid response from Spansh."
-msgstr "Received invalid response from Spansh."
-
-#: auto_neutron/route_plots.py:278 auto_neutron/windows/nearest_window.py:72
+#: auto_neutron/route_plots.py:299 auto_neutron/windows/nearest_window.py:85
 msgid "Received error from Spansh: {}"
 msgstr "Received error from Spansh: {}"
 
-#: auto_neutron/self_updater.py:110
+#: auto_neutron/route_plots.py:331
+msgid "Received invalid response from Spansh."
+msgstr "Received invalid response from Spansh."
+
+#: auto_neutron/self_updater.py:109
 msgid "Downloading new release"
 msgstr "Downloading new release"
 
-#: auto_neutron/self_updater.py:149
+#: auto_neutron/self_updater.py:148
 msgid "Unable to find appropriate new release."
 msgstr "Unable to find appropriate new release."
 
-#: auto_neutron/self_updater.py:220
+#: auto_neutron/self_updater.py:219
 msgid "Downloaded file does not match expected checksum."
 msgstr "Downloaded file does not match expected checksum."
 
-#: auto_neutron/self_updater.py:229
+#: auto_neutron/self_updater.py:228
 msgid "Unable to rename executable: "
 msgstr "Unable to rename executable: "
 
-#: auto_neutron/self_updater.py:234
+#: auto_neutron/self_updater.py:233
 msgid "Unable to create new executable: "
 msgstr "Unable to create new executable: "
 
-#: auto_neutron/self_updater.py:245
+#: auto_neutron/self_updater.py:244
 msgid "Unable to create temporary directory: "
 msgstr "Unable to create temporary directory: "
 
-#: auto_neutron/self_updater.py:254
+#: auto_neutron/self_updater.py:253
 msgid "Unable to move files into temporary directory: "
 msgstr "Unable to move files into temporary directory: "
 
-#: auto_neutron/self_updater.py:262
+#: auto_neutron/self_updater.py:261
 msgid "Unable to extract new release files: "
 msgstr "Unable to extract new release files: "
 
-#: auto_neutron/windows/download_confirm_dialog.py:45
+#: auto_neutron/utils/utils.py:119
+msgid "<Main menu>"
+msgstr "<Main menu>"
+
+#: auto_neutron/windows/download_confirm_dialog.py:44
 msgid "A new release is available: {} -> {}"
 msgstr "A new release is available: {} -> {}"
 
@@ -67,7 +71,7 @@ msgstr "A new release is available: {} -> {}"
 msgid "Multiple unexpected errors have occurred (x{})"
 msgstr "Multiple unexpected errors have occurred (x{})"
 
-#: auto_neutron/windows/license_window.py:47
+#: auto_neutron/windows/license_window.py:56
 msgid ""
 "        Auto_Neutron Copyright (C) 2019 Numerlor\\\n"
 "        This program comes with ABSOLUTELY NO WARRANTY.\\\n"
@@ -86,6 +90,9 @@ msgid ""
 "        {python_copyright_notice}\n"
 "          Python is licensed under the {psf_license_agreement_hyperlink},"
 " see {python_licenses_hyperlink} for more details\n"
+"\n"
+"        And The Breeze Icons Theme Copyright (C) 2014 Uri Herrera "
+"<uri_herrera@nitrux.in> and others, under the {lgplv3_hyperlink}.\n"
 "        "
 msgstr ""
 "        Auto_Neutron Copyright (C) 2019 Numerlor\\\n"
@@ -105,29 +112,36 @@ msgstr ""
 "        {python_copyright_notice}\n"
 "          Python is licensed under the {psf_license_agreement_hyperlink},"
 " see {python_licenses_hyperlink} for more details\n"
+"\n"
+"        And The Breeze Icons Theme Copyright (C) 2014 Uri Herrera "
+"<uri_herrera@nitrux.in> and others, under the {lgplv3_hyperlink}.\n"
 "        "
 
-#: auto_neutron/windows/license_window.py:66
+#: auto_neutron/windows/license_window.py:77
 msgid "GPLv3 license"
 msgstr "GPLv3 license"
 
-#: auto_neutron/windows/license_window.py:68
+#: auto_neutron/windows/license_window.py:79
+msgid "LGPLv3 license"
+msgstr "LGPLv3 license"
+
+#: auto_neutron/windows/license_window.py:82
 msgid "gnu.org/licenses"
 msgstr "gnu.org/licenses"
 
-#: auto_neutron/windows/license_window.py:71
+#: auto_neutron/windows/license_window.py:85
 msgid "PSF License Agreement"
 msgstr "PSF License Agreement"
 
-#: auto_neutron/windows/license_window.py:74
+#: auto_neutron/windows/license_window.py:88
 msgid "docs.python.org/license.html"
 msgstr "docs.python.org/license.html"
 
-#: auto_neutron/windows/license_window.py:76
+#: auto_neutron/windows/license_window.py:90
 msgid "MIT license"
 msgstr "MIT license"
 
-#: auto_neutron/windows/license_window.py:78
+#: auto_neutron/windows/license_window.py:92
 msgid "3-Clause BSD license"
 msgstr "3-Clause BSD license"
 
@@ -153,57 +167,65 @@ msgstr "Neutron"
 msgid "Jumps"
 msgstr "Jumps"
 
-#: auto_neutron/windows/new_route_window.py:168
+#: auto_neutron/windows/new_route_window.py:163
 msgid "Invalid ship data in clipboard."
 msgstr "Invalid ship data in clipboard."
 
-#: auto_neutron/windows/new_route_window.py:336
+#: auto_neutron/windows/new_route_window.py:357
 msgid "Select CSV file"
 msgstr "Select CSV file"
 
-#: auto_neutron/windows/new_route_window.py:336
+#: auto_neutron/windows/new_route_window.py:357
 msgid "CSV (*.csv);;All types (*.*)"
 msgstr "CSV (*.csv);;All types (*.*)"
 
-#: auto_neutron/windows/new_route_window.py:365
+#: auto_neutron/windows/new_route_window.py:386
 msgid "Invalid CSV file."
 msgstr "Invalid CSV file."
 
-#: auto_neutron/windows/new_route_window.py:370
+#: auto_neutron/windows/new_route_window.py:391
 msgid "CSV file doesn't exist."
 msgstr "CSV file doesn't exist."
 
-#: auto_neutron/windows/new_route_window.py:372
+#: auto_neutron/windows/new_route_window.py:393
 msgid "Invalid CSV file: "
 msgstr "Invalid CSV file: "
 
-#: auto_neutron/windows/new_route_window.py:374
+#: auto_neutron/windows/new_route_window.py:395
 msgid "Truncated data in CSV file."
 msgstr "Truncated data in CSV file."
 
-#: auto_neutron/windows/new_route_window.py:376
+#: auto_neutron/windows/new_route_window.py:397
 msgid "Invalid data in CSV file."
 msgstr "Invalid data in CSV file."
 
-#: auto_neutron/windows/new_route_window.py:378
+#: auto_neutron/windows/new_route_window.py:399
 msgid "Invalid path."
 msgstr "Invalid path."
 
-#: auto_neutron/windows/new_route_window.py:439
-msgid "Selected journal ended with a shut down event."
-msgstr "Selected journal ended with a shut down event."
+#: auto_neutron/windows/new_route_window.py:477
+msgid "Found no active journal files from within the last week."
+msgstr "Found no active journal files from within the last week."
+
+#: auto_neutron/windows/new_route_window.py:521
+msgid "Selected journal using {}, created at {}"
+msgstr "Selected journal using {}, created at {}"
+
+#: auto_neutron/windows/new_route_window.py:555
+msgid "Selected journal got shut down, available journals refreshed."
+msgstr "Selected journal got shut down, available journals refreshed."
 
 #. NOTE: Source system
-#: auto_neutron/windows/new_route_window.py:540
+#: auto_neutron/windows/new_route_window.py:635
 msgid "Source: {}"
 msgstr "Source: {}"
 
-#: auto_neutron/windows/new_route_window.py:543
+#: auto_neutron/windows/new_route_window.py:638
 msgid "Saved location: {}"
 msgstr "Saved location: {}"
 
 #. NOTE: destination system
-#: auto_neutron/windows/new_route_window.py:547
+#: auto_neutron/windows/new_route_window.py:642
 msgid "Destination: {}"
 msgstr "Destination: {}"
 
@@ -246,51 +268,51 @@ msgid "Quit"
 msgstr "Quit"
 
 #: auto_neutron/windows/gui/error_window.py:49
-#: auto_neutron/windows/gui/main_window.py:136
+#: auto_neutron/windows/gui/main_window.py:133
 #: auto_neutron/windows/gui/shut_down_window.py:72
 msgid "Save route"
 msgstr "Save route"
 
-#: auto_neutron/windows/gui/license_window.py:54
+#: auto_neutron/windows/gui/license_window.py:52
 msgid "About Qt"
 msgstr "About Qt"
 
-#: auto_neutron/windows/gui/license_window.py:55
+#: auto_neutron/windows/gui/license_window.py:53
 msgid "Back"
 msgstr "Back"
 
-#: auto_neutron/windows/gui/main_window.py:135
+#: auto_neutron/windows/gui/main_window.py:132
 msgid "Edit"
 msgstr "Edit"
 
-#: auto_neutron/windows/gui/main_window.py:137
+#: auto_neutron/windows/gui/main_window.py:134
 msgid "Copy"
 msgstr "Copy"
 
-#: auto_neutron/windows/gui/main_window.py:138
+#: auto_neutron/windows/gui/main_window.py:135
 msgid "Start a new route"
 msgstr "Start a new route"
 
-#: auto_neutron/windows/gui/main_window.py:139
-#: auto_neutron/windows/gui/settings_window.py:344
+#: auto_neutron/windows/gui/main_window.py:136
+#: auto_neutron/windows/gui/settings_window.py:343
 msgid "Settings"
 msgstr "Settings"
 
-#: auto_neutron/windows/gui/main_window.py:140
+#: auto_neutron/windows/gui/main_window.py:137
 msgid "About"
 msgstr "About"
 
-#: auto_neutron/windows/gui/main_window.py:145
+#: auto_neutron/windows/gui/main_window.py:142
 #: auto_neutron/windows/gui/nearest_window.py:131
 msgid "System name"
 msgstr "System name"
 
-#: auto_neutron/windows/gui/main_window.py:147
+#: auto_neutron/windows/gui/main_window.py:144
 #: auto_neutron/windows/gui/nearest_window.py:132
 msgid "Distance"
 msgstr "Distance"
 
-#: auto_neutron/windows/gui/main_window.py:149
+#: auto_neutron/windows/gui/main_window.py:146
 msgid "Remaining"
 msgstr "Remaining"
 
@@ -349,157 +371,158 @@ msgstr "Copy searched system name to the destination input"
 msgid "Search"
 msgstr "Search"
 
-#: auto_neutron/windows/gui/new_route_window.py:90
+#: auto_neutron/windows/gui/new_route_window.py:129
 msgid "Source system"
 msgstr "Source system"
 
-#: auto_neutron/windows/gui/new_route_window.py:91
+#: auto_neutron/windows/gui/new_route_window.py:130
 msgid "Destination system"
 msgstr "Destination system"
 
-#: auto_neutron/windows/gui/new_route_window.py:93
+#: auto_neutron/windows/gui/new_route_window.py:132
 msgid "Cargo"
 msgstr "Cargo"
 
-#: auto_neutron/windows/gui/new_route_window.py:95
+#: auto_neutron/windows/gui/new_route_window.py:134
 msgid "Submit"
 msgstr "Submit"
 
-#: auto_neutron/windows/gui/new_route_window.py:97
-#: auto_neutron/windows/gui/shut_down_window.py:75
-msgid "Last journal"
-msgstr "Last journal"
+#: auto_neutron/windows/gui/new_route_window.py:135
+msgid "Abort"
+msgstr "Abort"
 
-#: auto_neutron/windows/gui/new_route_window.py:97
-#: auto_neutron/windows/gui/shut_down_window.py:75
-msgid "Second to last"
-msgstr "Second to last"
+#: auto_neutron/windows/gui/new_route_window.py:136
+msgid "Cancel the current route plot"
+msgstr "Cancel the current route plot"
 
-#: auto_neutron/windows/gui/new_route_window.py:97
-#: auto_neutron/windows/gui/shut_down_window.py:75
-msgid "Third to last"
-msgstr "Third to last"
+#: auto_neutron/windows/gui/new_route_window.py:137
+msgid "Refresh journals"
+msgstr "Refresh journals"
 
-#: auto_neutron/windows/gui/new_route_window.py:154
+#: auto_neutron/windows/gui/new_route_window.py:189
 msgid "Range"
 msgstr "Range"
 
-#: auto_neutron/windows/gui/new_route_window.py:155
+#: auto_neutron/windows/gui/new_route_window.py:190
 msgid "Efficiency"
 msgstr "Efficiency"
 
-#: auto_neutron/windows/gui/new_route_window.py:156
-#: auto_neutron/windows/gui/new_route_window.py:206
+#: auto_neutron/windows/gui/new_route_window.py:191
+#: auto_neutron/windows/gui/new_route_window.py:241
 msgid "Nearest"
 msgstr "Nearest"
 
-#: auto_neutron/windows/gui/new_route_window.py:201
+#: auto_neutron/windows/gui/new_route_window.py:236
 msgid "Already supercharged"
 msgstr "Already supercharged"
 
-#: auto_neutron/windows/gui/new_route_window.py:202
+#: auto_neutron/windows/gui/new_route_window.py:237
 msgid "Use supercharge"
 msgstr "Use supercharge"
 
-#: auto_neutron/windows/gui/new_route_window.py:203
+#: auto_neutron/windows/gui/new_route_window.py:238
 msgid "Use FSD injections"
 msgstr "Use FSD injections"
 
-#: auto_neutron/windows/gui/new_route_window.py:204
+#: auto_neutron/windows/gui/new_route_window.py:239
 msgid "Exclude secondary stars"
 msgstr "Exclude secondary stars"
 
-#: auto_neutron/windows/gui/new_route_window.py:205
+#: auto_neutron/windows/gui/new_route_window.py:240
 msgid "Use ship from clipboard"
 msgstr "Use ship from clipboard"
 
-#: auto_neutron/windows/gui/new_route_window.py:309
-msgid "CSV"
-msgstr "CSV"
+#: auto_neutron/windows/gui/new_route_window.py:271
+msgid "CSV path"
+msgstr "CSV path"
 
-#: auto_neutron/windows/gui/new_route_window.py:310
+#: auto_neutron/windows/gui/new_route_window.py:359
 msgid "Neutron plotter"
 msgstr "Neutron plotter"
 
-#: auto_neutron/windows/gui/new_route_window.py:311
+#: auto_neutron/windows/gui/new_route_window.py:360
 msgid "Galaxy plotter"
 msgstr "Galaxy plotter"
 
-#: auto_neutron/windows/gui/new_route_window.py:312
+#: auto_neutron/windows/gui/new_route_window.py:361
+msgid "CSV"
+msgstr "CSV"
+
+#: auto_neutron/windows/gui/new_route_window.py:362
 msgid "Saved route"
 msgstr "Saved route"
 
-#: auto_neutron/windows/gui/settings_window.py:66
+#: auto_neutron/windows/gui/settings_window.py:65
 msgid "Bold"
 msgstr "Bold"
 
-#: auto_neutron/windows/gui/settings_window.py:67
+#: auto_neutron/windows/gui/settings_window.py:66
 #, fuzzy
 msgid "Language"
 msgstr "Language"
 
-#: auto_neutron/windows/gui/settings_window.py:68
+#: auto_neutron/windows/gui/settings_window.py:67
 msgid "Dark mode"
 msgstr "Dark mode"
 
-#: auto_neutron/windows/gui/settings_window.py:95
+#: auto_neutron/windows/gui/settings_window.py:94
 msgid "Save route on window close"
 msgstr "Save route on window close"
 
-#: auto_neutron/windows/gui/settings_window.py:96
+#: auto_neutron/windows/gui/settings_window.py:95
 msgid "Copy Mode"
 msgstr "Copy Mode"
 
-#: auto_neutron/windows/gui/settings_window.py:97
+#: auto_neutron/windows/gui/settings_window.py:96
 msgid "AHK Path"
 msgstr "AHK Path"
 
-#: auto_neutron/windows/gui/settings_window.py:98
+#: auto_neutron/windows/gui/settings_window.py:97
 msgid "Auto scroll"
 msgstr "Auto scroll"
 
-#: auto_neutron/windows/gui/settings_window.py:148
+#: auto_neutron/windows/gui/settings_window.py:147
 msgid "Taskbar fuel alert"
 msgstr "Taskbar fuel alert"
 
-#: auto_neutron/windows/gui/settings_window.py:149
+#: auto_neutron/windows/gui/settings_window.py:148
 msgid "Sound fuel alert"
 msgstr "Sound fuel alert"
 
-#: auto_neutron/windows/gui/settings_window.py:150
+#: auto_neutron/windows/gui/settings_window.py:149
 msgid "Custom sound alert file:"
 msgstr "Custom sound alert file:"
 
-#: auto_neutron/windows/gui/settings_window.py:152
+#: auto_neutron/windows/gui/settings_window.py:151
 #, python-format
 msgid "%% of maximum fuel usage left in tank before triggering alert"
 msgstr "%% of maximum fuel usage left in tank before triggering alert"
 
-#: auto_neutron/windows/gui/settings_window.py:204
+#: auto_neutron/windows/gui/settings_window.py:203
 msgid "Galaxy map open key"
 msgstr "Galaxy map open key"
 
-#: auto_neutron/windows/gui/settings_window.py:205
+#: auto_neutron/windows/gui/settings_window.py:204
 msgid "Time to wait for galaxy map to open"
 msgstr "Time to wait for galaxy map to open"
 
-#: auto_neutron/windows/gui/settings_window.py:206
+#: auto_neutron/windows/gui/settings_window.py:205
 msgid "Key to use to navigate right in the map"
 msgstr "Key to use to navigate right in the map"
 
-#: auto_neutron/windows/gui/settings_window.py:209
+#: auto_neutron/windows/gui/settings_window.py:208
 msgid "Key to use to focus onto the system input field"
 msgstr "Key to use to focus onto the system input field"
 
-#: auto_neutron/windows/gui/settings_window.py:212
+#: auto_neutron/windows/gui/settings_window.py:211
 msgid "Key to submit the entered system"
 msgstr "Key to submit the entered system"
 
-#: auto_neutron/windows/gui/settings_window.py:215
+#: auto_neutron/windows/gui/settings_window.py:214
 msgid "AutoHotKey key reference"
 msgstr "AutoHotKey key reference"
 
-#: auto_neutron/windows/gui/settings_window.py:260
+#: auto_neutron/windows/gui/settings_window.py:259
 msgid ""
 "Bind to trigger the script, # for win key, ! for alt, ^ for control, + "
 "for shift"
@@ -507,11 +530,11 @@ msgstr ""
 "Bind to trigger the script, # for win key, ! for alt, ^ for control, + "
 "for shift"
 
-#: auto_neutron/windows/gui/settings_window.py:263
+#: auto_neutron/windows/gui/settings_window.py:262
 msgid "Simple mode"
 msgstr "Simple mode"
 
-#: auto_neutron/windows/gui/settings_window.py:264
+#: auto_neutron/windows/gui/settings_window.py:263
 msgid ""
 "With Simple mode enabled, a default script filled with the specified "
 "settings is used, if simple mode is not enabled, the script can be fully "
@@ -521,27 +544,27 @@ msgstr ""
 "settings is used, if simple mode is not enabled, the script can be fully "
 "customized."
 
-#: auto_neutron/windows/gui/settings_window.py:333
+#: auto_neutron/windows/gui/settings_window.py:332
 msgid "Ok"
 msgstr "Ok"
 
-#: auto_neutron/windows/gui/settings_window.py:334
+#: auto_neutron/windows/gui/settings_window.py:333
 msgid "Apply"
 msgstr "Apply"
 
-#: auto_neutron/windows/gui/settings_window.py:338
+#: auto_neutron/windows/gui/settings_window.py:337
 msgid "Appearance"
 msgstr "Appearance"
 
-#: auto_neutron/windows/gui/settings_window.py:338
+#: auto_neutron/windows/gui/settings_window.py:337
 msgid "Behaviour"
 msgstr "Behaviour"
 
-#: auto_neutron/windows/gui/settings_window.py:338
+#: auto_neutron/windows/gui/settings_window.py:337
 msgid "Alerts"
 msgstr "Alerts"
 
-#: auto_neutron/windows/gui/settings_window.py:338
+#: auto_neutron/windows/gui/settings_window.py:337
 msgid "AHK script"
 msgstr "AHK script"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -84,6 +84,14 @@ python-versions = "*"
 altgraph = ">=0.15"
 
 [[package]]
+name = "more-itertools"
+version = "8.12.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "mslex"
 version = "0.3.0"
 description = "shlex for windows"
@@ -305,7 +313,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "3.10.*"
-content-hash = "9ad3b48f4d232c19d156badbf8dd5f121d9c4e9d2f5e4cfe1fe64fae6207254f"
+content-hash = "090497ff57c31abc119f0f0fede905061e809a1a33af243a4d1160f4acdd7b5e"
 
 [metadata.files]
 altgraph = [
@@ -342,6 +350,10 @@ identify = [
 macholib = [
     {file = "macholib-1.15.2-py2.py3-none-any.whl", hash = "sha256:885613dd02d3e26dbd2b541eb4cc4ce611b841f827c0958ab98656e478b9e6f6"},
     {file = "macholib-1.15.2.tar.gz", hash = "sha256:1542c41da3600509f91c165cb897e7e54c0e74008bd8da5da7ebbee519d593d2"},
+]
+more-itertools = [
+    {file = "more-itertools-8.12.0.tar.gz", hash = "sha256:7dc6ad46f05f545f900dd59e8dfb4e84a4827b97b3cfecb175ea0c7d247f6064"},
+    {file = "more_itertools-8.12.0-py3-none-any.whl", hash = "sha256:43e6dd9942dffd72661a2c4ef383ad7da1e6a3e968a927ad7a6083ab410a688b"},
 ]
 mslex = [
     {file = "mslex-0.3.0-py2.py3-none-any.whl", hash = "sha256:380cb14abf8fabf40e56df5c8b21a6d533dc5cbdcfe42406bbf08dda8f42e42a"},

--- a/pyinstaller_build/build.py
+++ b/pyinstaller_build/build.py
@@ -8,10 +8,10 @@ import subprocess  # noqa S404
 import sys
 from pathlib import Path
 
-import delete_babel_dat
 import dotenv
 import PyInstaller.__main__
 
+import delete_babel_dat
 import delete_dlls
 
 dotenv.load_dotenv()

--- a/pyinstaller_build/delete_dlls.py
+++ b/pyinstaller_build/delete_dlls.py
@@ -17,7 +17,6 @@ ROOT_DELETE = (
     "Qt6OpenGL.dll",
     "Qt6Quick.dll",
     "Qt6QmlModels.dll",
-    "Qt6Svg.dll",
     "Qt6VirtualKeyboard.dll",
 )
 PLUGINS_DELETE = (

--- a/pyinstaller_build/delete_dlls.py
+++ b/pyinstaller_build/delete_dlls.py
@@ -25,7 +25,6 @@ PLUGINS_DELETE = (
     "imageformats/qgif.dll",
     "imageformats/qicns.dll",
     "imageformats/qjpeg.dll",
-    "imageformats/qsvg.dll",
     "imageformats/qtga.dll",
     "imageformats/qtiff.dll",
     "imageformats/qwbmp.dll",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Auto_Neutron"
-version = "2.0.9"
+version = "2.1.0"
 description = "An automatic neutron route plotter for Elite Dangerous"
 authors = ["Numerlor <numerlor@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ PySide6 = "~6.2.0"
 tomli = "~2.0.1"
 tomli-w = "~1.0.0"
 babel = "~2.9.1"
+more-itertools = "~8.12.0"
 
 [tool.poetry.dev-dependencies]
 typing-extensions = ">=4.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ multi_line_output = 3
 line_length = 88
 include_trailing_comma = true
 use_parentheses = true
-known_first_party = ["auto_neutron", "__feature__", "delete_dlls"]
+known_first_party = ["auto_neutron", "__feature__", "delete_dlls", "delete_babel_dat"]
 
 [tool.black]
 target-version = ["py310"]

--- a/resources/LICENSE_BREEZE.md
+++ b/resources/LICENSE_BREEZE.md
@@ -1,0 +1,209 @@
+The Breeze Icon Theme, refresh.svg and view-refresh-dark.svg
+
+    Copyright (C) 2014 Uri Herrera <uri_herrera@nitrux.in> and others
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+Clarification:
+
+  The GNU Lesser General Public License or LGPL is written for
+  software libraries in the first place. We expressly want the LGPL to
+  be valid for this artwork library too.
+
+  KDE Breeze theme icons is a special kind of software library, it is an
+  artwork library, it's elements can be used in a Graphical User Interface, or
+  GUI.
+
+  Source code, for this library means:
+   - where they exist, SVG;
+   - otherwise, if applicable, the multi-layered formats xcf or psd, or
+  otherwise png.
+
+  The LGPL in some sections obliges you to make the files carry
+  notices. With images this is in some cases impossible or hardly useful.
+
+  With this library a notice is placed at a prominent place in the directory
+  containing the elements. You may follow this practice.
+
+  The exception in section 5 of the GNU Lesser General Public License covers
+  the use of elements of this art library in a GUI.
+
+ https://vdesign.kde.org/
+
+-----
+		   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/resources/refresh-dark.svg
+++ b/resources/refresh-dark.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa40b760366c7816882cc90bee883e3923139d9186f0999379950315ae627e09
+size 1794

--- a/resources/refresh.svg
+++ b/resources/refresh.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd2d3a9c8177b90c1001ddbca5887cf5a25f3936ad4b7890cb52f32c0b42c64f
+size 1794


### PR DESCRIPTION
- Use journal directly instead of mirroring state in GameState
- use a new journal selection format, which displays names of cmdrs of the available journals instead of only indexing into them
- refresh for the journals
- all journals are now cached, and only load new data when parsed
- additional information when a journal is selected: The game mode and creation time
- window package now reexports window classes
- back button in license window disabled when at "home" page
- fixed nearest window that was passed a non existing function and errored
- workers can't be restarted again with a nice error, instead of erroring on generator advance
- csv tab was moved to the third position
- fixed missing localizations
- route index is clamped to the route's length to prevent errors with out of bound indices
- route requests can now be aborted by user
- all requests are aborted when closing a window or starting a new request
- fixed display of made jumps with exact route