### PR TITLE
feat: update requirements to support python3.13

### DIFF
--- a/requirements-with-dev.txt
+++ b/requirements-with-dev.txt
@@ -1,61 +1,61 @@
-altgraph==0.17.4 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+altgraph==0.17.4 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:1b5afbb98f6c4dcadb2e2ae6ab9fa994bbb8c1d75f4fa96d340f9437ae454406 \
     --hash=sha256:642743b4750de17e655e6711601b077bc6598dbfa3ba5fa2b2a35ce12b508dff
-asn1crypto==1.5.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+asn1crypto==1.5.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c \
     --hash=sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67
-babel==2.16.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+babel==2.16.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b \
     --hash=sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316
-certvalidator==0.11.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+certvalidator==0.11.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:77520b269f516d4fb0902998d5bd0eb3727fe153b659aa1cb828dcf12ea6b8de \
     --hash=sha256:922d141c94393ab285ca34338e18dd4093e3ae330b1f278e96c837cb62cffaad
-cfgv==3.4.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+cfgv==3.4.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9 \
     --hash=sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560
-colorama==0.4.6 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+colorama==0.4.6 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-distlib==0.3.8 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+distlib==0.3.8 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784 \
     --hash=sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64
-filelock==3.15.4 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+filelock==3.15.4 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb \
     --hash=sha256:6ca1fffae96225dab4c6eaf1c4f4f28cd2568d3ec2a44e15a08520504de468e7
-identify==2.6.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+identify==2.6.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:cb171c685bdc31bcc4c1734698736a7d5b6c8bf2e0c15117f4d469c8640ae5cf \
     --hash=sha256:e79ae4406387a9d300332b5fd366d8994f1525e8414984e1a59e058b2eda2dd0
-macholib==1.16.3 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" and sys_platform == "darwin" \
+macholib==1.16.3 ; python_version >= "3.12.dev0" and python_version < "3.14" and sys_platform == "darwin" \
     --hash=sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30 \
     --hash=sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c
-more-itertools==10.4.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+more-itertools==10.4.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:0f7d9f83a0a8dcfa8a2694a770590d98a67ea943e3d9f5298309a484758c4e27 \
     --hash=sha256:fe0e63c4ab068eac62410ab05cccca2dc71ec44ba8ef29916a0090df061cf923
-mscerts==2024.5.29 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+mscerts==2024.5.29 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:0c1c548ec8f4f56c328891db789e954a3c14ee8c20483ff383795cfa669f44ea \
     --hash=sha256:f33523ed8e0a81f36f71da6597472e604910a70f7b4a9a9ced9df1d0c9465a55
-mslex==1.2.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" and sys_platform == "win32" \
+mslex==1.2.0 ; python_version >= "3.12.dev0" and python_version < "3.14" and sys_platform == "win32" \
     --hash=sha256:79e2abc5a129dd71cdde58a22a2039abb7fa8afcbac498b723ba6e9b9fbacc14 \
     --hash=sha256:c68ec637485ee3544c5847c1b4e78b02940b32708568fb1d8715491815aa2341
-nodeenv==1.9.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+nodeenv==1.9.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f \
     --hash=sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9
-oscrypto==1.3.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+oscrypto==1.3.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:2b2f1d2d42ec152ca90ccb5682f3e051fb55986e1b170ebde472b133713e7085 \
     --hash=sha256:6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4
-packaging==24.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+packaging==24.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002 \
     --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
-pefile==2023.2.7 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" and sys_platform == "win32" \
+pefile==2023.2.7 ; python_version >= "3.12.dev0" and python_version < "3.14" and sys_platform == "win32" \
     --hash=sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc \
     --hash=sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6
-platformdirs==4.2.2 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+platformdirs==4.2.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee \
     --hash=sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3
-pre-commit==3.8.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+pre-commit==3.8.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af \
     --hash=sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f
-psutil==5.9.8 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+psutil==5.9.8 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:02615ed8c5ea222323408ceba16c60e99c3f91639b07da6373fb7e6539abc56d \
     --hash=sha256:05806de88103b25903dff19bb6692bd2e714ccf9e668d050d144012055cbca73 \
     --hash=sha256:26bd09967ae00920df88e0352a91cff1a78f8d69b3ecabbfe733610c0af486c8 \
@@ -72,50 +72,50 @@ psutil==5.9.8 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
     --hash=sha256:bd1184ceb3f87651a67b2708d4c3338e9b10c5df903f2e3776b62303b26cb631 \
     --hash=sha256:d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4 \
     --hash=sha256:d16bbddf0693323b8c6123dd804100241da461e41d6e332fb0ba6058f630f8c8
-pyasn1-modules==0.4.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+pyasn1-modules==0.4.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6 \
     --hash=sha256:be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b
-pyasn1==0.6.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+pyasn1==0.6.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c \
     --hash=sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473
-pyinstaller-hooks-contrib==2024.8 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+pyinstaller-hooks-contrib==2024.8 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:0057fe9a5c398d3f580e73e58793a1d4a8315ca91c3df01efea1c14ed557825a \
     --hash=sha256:29b68d878ab739e967055b56a93eb9b58e529d5b054fbab7a2f2bacf80cef3e2
-pyinstaller==6.10.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
-    --hash=sha256:143840f8056ff7b910bf8f16f6cd92cc10a6c2680bb76d0a25d558d543d21270 \
-    --hash=sha256:28eca3817f176fdc19747e1afcf434f13bb9f17a644f611be2c5a61b1f498ed7 \
-    --hash=sha256:308e0a8670c9c9ac0cebbf1bbb492e71b6675606f2ec78bc4adfc830d209e087 \
-    --hash=sha256:3398a98fa17d47ccb31f8779ecbdacec025f7adb2f22757a54b706ac8b4fe906 \
-    --hash=sha256:46d75359668993ddd98630a3669dc5249f3c446e35239b43bc7f4155bc574748 \
-    --hash=sha256:6cf876d7d93b8b4f28d1ad57fa24645cf43119c79e985dd5e5f7a801245e6f53 \
-    --hash=sha256:703e041718987e46ba0568a2c71ecf2459fddef57cf9edf3efeed4a53e3dae3f \
-    --hash=sha256:95b55966e563e8b8f31a43882aea10169e9a11fdf38e626d86a2907b640c0701 \
-    --hash=sha256:b7c90c91921b3749083115b28f30f40abf2bb481ceff196d2b2ce0eaa2b3d429 \
-    --hash=sha256:d60fb22859e11483af735aec115fdde09467cdbb29edd9844839f2c920b748c0 \
-    --hash=sha256:db05e3f2f10f9f78c56f1fb163d9cb453433429fe4281218ebaf1ebfd39ba942 \
-    --hash=sha256:e9989f354ae4ed8a3bec7bdb37ae0d170751d6520e500f049c7cd0632d31d5c3
-pyside6-addons==6.7.2 ; python_version >= "3.12.dev0" and python_version < "3.13" \
-    --hash=sha256:22979b1aa09d9cf1d7a86c8a9aa0cb4791d6bd1cc94f96c5b6780c5ef8a9e34e \
-    --hash=sha256:90b995efce61058d995c603ea480a9a3054fe8206739dcbc273fc3b53d40650f \
-    --hash=sha256:94b9bf6a2a4a7ac671e1776633e50d51326c86f4184f1c6e556f4dd5498fd52a \
-    --hash=sha256:ebf549eb25998665d8e4ec24014fbbd37bebc5ecdcb050b34db1e1c03e1bf81d
-pyside6-essentials==6.7.2 ; python_version >= "3.12.dev0" and python_version < "3.13" \
-    --hash=sha256:0111d5fa8cf826de3ca9d82fed54726cce116d57f454f88a6467578652032d69 \
-    --hash=sha256:4d13666e796ec140ecfb432c4f3d7baef6dfafc11929985a83b22c0025532fb7 \
-    --hash=sha256:9135513e1c4c6e2fbb1e4f9afcb3d42e54708b0d9ed870cb3213ea4874cafa1e \
-    --hash=sha256:a1a4c09f1e916b9cfe53151fe4a503a6acb1f6621ba28204d1bfe636f80d6780
-pyside6==6.7.2 ; python_version >= "3.12.dev0" and python_version < "3.13" \
-    --hash=sha256:15e7696a09072ee977f6e6179ab1e48184953df8417bcaa83cfadf0b79747242 \
-    --hash=sha256:602debef9ec159b0db48f83b38a0e43e2dad3961f7d99f708d98620f04e9112b \
-    --hash=sha256:6e0acb471535de303f56e3077aa86f53496b4de659b99ecce80520bcee508a63 \
-    --hash=sha256:f73ae0de77d67f51ca3ce8207b12d3a5fa0107d3d5b6e4aeb3b53ee842b0927a
-python-dotenv==1.0.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+pyinstaller==6.11.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
+    --hash=sha256:04f71828aa9531ab18c9656985c1f09b83d10332c73a1f4a113a48b491906955 \
+    --hash=sha256:0e229610c22b96d741d905706f9496af472c1a9216a118988f393c98ecc3f51f \
+    --hash=sha256:6fd68a3c1207635c49326c54881b89d5c3bd9ba061bbc9daa58c0902db1be39e \
+    --hash=sha256:7d2cd2ebdcd6860f8a4abe2977264a7b6d260a7147047008971c7cfc66a656a4 \
+    --hash=sha256:963dedc1f37144a4385f58f7f65f1c69c004a67faae522a2085b5ddb230c908b \
+    --hash=sha256:a5f716bb507517912fda39d109dead91fc0dd2e7b2859562522b63c61aa21676 \
+    --hash=sha256:a843d470768d68b05684ccf4860c45b2eb13727f41667c0b2cd8f57ae231bd18 \
+    --hash=sha256:c71024c8a19c7b221b9152b2baff4c3ba849cada68dcdd34382ba09f0107451f \
+    --hash=sha256:cb4d433a3db30d9d17cf5f2cf7bb4df80a788d493c1d67dd822dc5791d9864af \
+    --hash=sha256:d9ec6d4398b4eebc1d4c00437716264ba8406bc2746f594e253070a82378a584 \
+    --hash=sha256:e6d229009e815542833fe00332b589aa6984a06f794dc16f2ce1acab1c567590 \
+    --hash=sha256:eddd53f231e51adc65088eac4f40057ca803a990239828d4a9229407fb866239
+pyside6-addons==6.8.0.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
+    --hash=sha256:30c9ca570dd18ffbfd34ee95e0a319c34313a80425c4011d6ccc9f4cca0dc4c8 \
+    --hash=sha256:553f3fa412f423929b5cd8b7d43fd5f02161851f10a438174a198b0f1a044df7 \
+    --hash=sha256:754a9822ab2dc313f9998edef69d8a12bc9fd61727543f8d30806ed272ae1e52 \
+    --hash=sha256:ae4377a3e10fe720a9119677b31d8de13e2a5221c06b332df045af002f5f4c3d
+pyside6-essentials==6.8.0.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
+    --hash=sha256:3df4ed75bbb74d74ac338b330819b1a272e7f5cec206765c7176a197c8bc9c79 \
+    --hash=sha256:7df6d6c1da4858dbdea77c74d7270d9c68e8d1bbe3362892abd1a5ade3815a50 \
+    --hash=sha256:cf490145d18812a6cff48b0b0afb0bfaf7066744bfbd09eb071c3323f1d6d00d \
+    --hash=sha256:d2f029b8c9f0106f57b26aa8c435435d7f509c80525075343e07177b283f862e
+pyside6==6.8.0.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
+    --hash=sha256:3258f3c63dc5053b8d5b8d2588caca8bb3a36e2f74413511e4676df0e73b6f1e \
+    --hash=sha256:3e8fffca9a934e30c07c3f34bb572f84bfcf02385acbc715e65fbdd9746ecc2b \
+    --hash=sha256:6a25cf784f978fa2a23b4d089970b27ebe14d26adcaf38b2819cb04483de4ce9 \
+    --hash=sha256:cecc6ce1da6cb04542ff5a0887734f63e6ecf54258d1786285b9c7904abd9b01
+python-dotenv==1.0.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \
     --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
-pywin32-ctypes==0.2.3 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" and sys_platform == "win32" \
+pywin32-ctypes==0.2.3 ; python_version >= "3.12.dev0" and python_version < "3.14" and sys_platform == "win32" \
     --hash=sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8 \
     --hash=sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755
-pyyaml==6.0.2 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+pyyaml==6.0.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
     --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 \
     --hash=sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086 \
@@ -169,28 +169,28 @@ pyyaml==6.0.2 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
     --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
-setuptools==73.0.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+setuptools==73.0.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:b208925fcb9f7af924ed2dc04708ea89791e24bde0d3020b27df0e116088b34e \
     --hash=sha256:d59a3e788ab7e012ab2c4baed1b376da6366883ee20d7a5fc426816e3d7b1193
-shiboken6==6.7.2 ; python_version >= "3.12.dev0" and python_version < "3.13" \
-    --hash=sha256:50c33ac6317b673a1eb97a9abaafccb162c4ba0c9ca658a8e449c49a8aadc379 \
-    --hash=sha256:70e80737b27cd5d83504b373013b55e70462bd4a27217d919ff9a83958731990 \
-    --hash=sha256:9024e6afb2af1568ebfc8a5d07e4ff6c8829f40923eeb28901f535463e2b6b65 \
-    --hash=sha256:98bedf9a15f1d8ba1af3e4d1e7527f7946ce36da541e08074fd9dc9ab5ff1adf
-signify==0.6.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+shiboken6==6.8.0.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
+    --hash=sha256:1aaa8b7f9138818322ef029b2c487d1c6e00dc3f53084e62e1d11bdea47e47c2 \
+    --hash=sha256:9019e1fcfeed8bb350222e981748ef05a2fec11e31ddf616657be702f0b7a468 \
+    --hash=sha256:b11e750e696bb565d897e0f5836710edfb86bd355f87b09988bd31b2aad404d3 \
+    --hash=sha256:fa7d411c3c67b4296847b3f5f572268e219d947d029ff9d8bce72fe6982d92bc
+signify==0.6.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:bd19e3287edc0864143494756cd8b5c3bbb3cbebd0032d55b3f10802c70eb699
-taskipy==1.13.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+taskipy==1.13.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:2b52f0257958fed151f1340f7de93fcf0848f7a358ad62ba05c31c2ca04f89fe \
     --hash=sha256:56f42b7e508d9aed2c7b6365f8d3dab62dbd0c768c1ab606c819da4fc38421f7
-tomli-w==1.0.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+tomli-w==1.0.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463 \
     --hash=sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9
-tomli==2.0.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+tomli==2.0.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
-typing-extensions==4.12.2 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+typing-extensions==4.12.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
-virtualenv==20.26.3 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+virtualenv==20.26.3 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a \
     --hash=sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,52 +1,52 @@
-asn1crypto==1.5.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+asn1crypto==1.5.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c \
     --hash=sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67
-babel==2.16.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+babel==2.16.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b \
     --hash=sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316
-certvalidator==0.11.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+certvalidator==0.11.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:77520b269f516d4fb0902998d5bd0eb3727fe153b659aa1cb828dcf12ea6b8de \
     --hash=sha256:922d141c94393ab285ca34338e18dd4093e3ae330b1f278e96c837cb62cffaad
-more-itertools==10.4.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+more-itertools==10.4.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:0f7d9f83a0a8dcfa8a2694a770590d98a67ea943e3d9f5298309a484758c4e27 \
     --hash=sha256:fe0e63c4ab068eac62410ab05cccca2dc71ec44ba8ef29916a0090df061cf923
-mscerts==2024.5.29 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+mscerts==2024.5.29 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:0c1c548ec8f4f56c328891db789e954a3c14ee8c20483ff383795cfa669f44ea \
     --hash=sha256:f33523ed8e0a81f36f71da6597472e604910a70f7b4a9a9ced9df1d0c9465a55
-oscrypto==1.3.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+oscrypto==1.3.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:2b2f1d2d42ec152ca90ccb5682f3e051fb55986e1b170ebde472b133713e7085 \
     --hash=sha256:6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4
-pyasn1-modules==0.4.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+pyasn1-modules==0.4.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6 \
     --hash=sha256:be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b
-pyasn1==0.6.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+pyasn1==0.6.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c \
     --hash=sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473
-pyside6-addons==6.7.2 ; python_version >= "3.12.dev0" and python_version < "3.13" \
-    --hash=sha256:22979b1aa09d9cf1d7a86c8a9aa0cb4791d6bd1cc94f96c5b6780c5ef8a9e34e \
-    --hash=sha256:90b995efce61058d995c603ea480a9a3054fe8206739dcbc273fc3b53d40650f \
-    --hash=sha256:94b9bf6a2a4a7ac671e1776633e50d51326c86f4184f1c6e556f4dd5498fd52a \
-    --hash=sha256:ebf549eb25998665d8e4ec24014fbbd37bebc5ecdcb050b34db1e1c03e1bf81d
-pyside6-essentials==6.7.2 ; python_version >= "3.12.dev0" and python_version < "3.13" \
-    --hash=sha256:0111d5fa8cf826de3ca9d82fed54726cce116d57f454f88a6467578652032d69 \
-    --hash=sha256:4d13666e796ec140ecfb432c4f3d7baef6dfafc11929985a83b22c0025532fb7 \
-    --hash=sha256:9135513e1c4c6e2fbb1e4f9afcb3d42e54708b0d9ed870cb3213ea4874cafa1e \
-    --hash=sha256:a1a4c09f1e916b9cfe53151fe4a503a6acb1f6621ba28204d1bfe636f80d6780
-pyside6==6.7.2 ; python_version >= "3.12.dev0" and python_version < "3.13" \
-    --hash=sha256:15e7696a09072ee977f6e6179ab1e48184953df8417bcaa83cfadf0b79747242 \
-    --hash=sha256:602debef9ec159b0db48f83b38a0e43e2dad3961f7d99f708d98620f04e9112b \
-    --hash=sha256:6e0acb471535de303f56e3077aa86f53496b4de659b99ecce80520bcee508a63 \
-    --hash=sha256:f73ae0de77d67f51ca3ce8207b12d3a5fa0107d3d5b6e4aeb3b53ee842b0927a
-shiboken6==6.7.2 ; python_version >= "3.12.dev0" and python_version < "3.13" \
-    --hash=sha256:50c33ac6317b673a1eb97a9abaafccb162c4ba0c9ca658a8e449c49a8aadc379 \
-    --hash=sha256:70e80737b27cd5d83504b373013b55e70462bd4a27217d919ff9a83958731990 \
-    --hash=sha256:9024e6afb2af1568ebfc8a5d07e4ff6c8829f40923eeb28901f535463e2b6b65 \
-    --hash=sha256:98bedf9a15f1d8ba1af3e4d1e7527f7946ce36da541e08074fd9dc9ab5ff1adf
-signify==0.6.1 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+pyside6==6.8.0.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
+    --hash=sha256:3258f3c63dc5053b8d5b8d2588caca8bb3a36e2f74413511e4676df0e73b6f1e \
+    --hash=sha256:3e8fffca9a934e30c07c3f34bb572f84bfcf02385acbc715e65fbdd9746ecc2b \
+    --hash=sha256:6a25cf784f978fa2a23b4d089970b27ebe14d26adcaf38b2819cb04483de4ce9 \
+    --hash=sha256:cecc6ce1da6cb04542ff5a0887734f63e6ecf54258d1786285b9c7904abd9b01
+pyside6-addons==6.8.0.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
+    --hash=sha256:30c9ca570dd18ffbfd34ee95e0a319c34313a80425c4011d6ccc9f4cca0dc4c8 \
+    --hash=sha256:553f3fa412f423929b5cd8b7d43fd5f02161851f10a438174a198b0f1a044df7 \
+    --hash=sha256:754a9822ab2dc313f9998edef69d8a12bc9fd61727543f8d30806ed272ae1e52 \
+    --hash=sha256:ae4377a3e10fe720a9119677b31d8de13e2a5221c06b332df045af002f5f4c3d
+pyside6-essentials==6.8.0.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
+    --hash=sha256:3df4ed75bbb74d74ac338b330819b1a272e7f5cec206765c7176a197c8bc9c79 \
+    --hash=sha256:7df6d6c1da4858dbdea77c74d7270d9c68e8d1bbe3362892abd1a5ade3815a50 \
+    --hash=sha256:cf490145d18812a6cff48b0b0afb0bfaf7066744bfbd09eb071c3323f1d6d00d \
+    --hash=sha256:d2f029b8c9f0106f57b26aa8c435435d7f509c80525075343e07177b283f862e
+shiboken6==6.8.0.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
+    --hash=sha256:1aaa8b7f9138818322ef029b2c487d1c6e00dc3f53084e62e1d11bdea47e47c2 \
+    --hash=sha256:9019e1fcfeed8bb350222e981748ef05a2fec11e31ddf616657be702f0b7a468 \
+    --hash=sha256:b11e750e696bb565d897e0f5836710edfb86bd355f87b09988bd31b2aad404d3 \
+    --hash=sha256:fa7d411c3c67b4296847b3f5f572268e219d947d029ff9d8bce72fe6982d92bc
+signify==0.6.1 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:bd19e3287edc0864143494756cd8b5c3bbb3cbebd0032d55b3f10802c70eb699
-tomli-w==1.0.0 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+tomli-w==1.0.0 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463 \
     --hash=sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9
-typing-extensions==4.12.2 ; python_version >= "3.12.dev0" and python_version < "3.13.dev0" \
+typing-extensions==4.12.2 ; python_version >= "3.12.dev0" and python_version < "3.14" \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8


### PR DESCRIPTION
My intention was to do minimal changes to modules versions, yet supporting python3.13 as well as python3.12.